### PR TITLE
Added CONTRIBUTING guide with Confluent Platform instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,134 @@
+This guide describes how to develop and contribute pull requests to this connector.
+
+# Testing with Confluent Platform
+
+[Confluent Platform](https://docs.confluent.io/platform/7.2.1/overview.html) provides an easy mechanism for running
+Kafka locally via a single application. To try out the MarkLogic Kafka connector via the Confluent Platform, follow
+the steps below.
+
+## Install Confluent Platform with the MarkLogic Kafka connector
+
+First, [install the Confluent Platform](https://docs.confluent.io/platform/current/quickstart/ce-docker-quickstart.html#cp-quickstart-step-1)
+via the "Tar archive" option (the "Docker" option has not yet been tested).
+
+**Important!** After step 6 (installing the Datagen source connector) and before step 7 (starting Confluent Platform), 
+you'll need to install the MarkLogic Kafka connector into your Confluent Platform distribution. 
+
+To do so, modify `confluentHome` in `gradle-local.properties` (create this file in the root of this project if it 
+does not already exist) to point to where you extracted the Confluent Platform distribution - e.g.:
+
+    confluentHome=/Users/myusername/confluent-7.2.1
+
+Then build and copy the connector to the Confluent Platform directory that you configured above:
+
+    ./gradlew copyConnectorToConfluent
+
+Note that any time you modify the MarkLogic Kafka connector code, you'll need to repeat the 
+`./gradlew copyConnectorToConfluent` step.
+
+Next, start Confluent:
+
+    confluent local services start
+
+To verify that your Confluent installation is running properly, you can run `confluent local services status` and
+see logging similar to this:
+
+```
+Using CONFLUENT_CURRENT: /var/folders/wn/l42pccj17rbfw6h_5b8bt2nnkpch_s/T/confluent.995873
+Connect is [UP]
+Control Center is [UP]
+Kafka is [UP]
+Kafka REST is [UP]
+ksqlDB Server is [UP]
+Schema Registry is [UP]
+ZooKeeper is [UP]
+```
+
+You can now visit http://localhost:9021 to access [Confluent's Control Center](https://docs.confluent.io/platform/current/control-center/index.html)
+application.
+
+Within Control Center, click on "controlcenter.cluster" to access the configuration for the Kafka cluster.
+
+
+## Load a Datagen connector instance
+
+To test out the MarkLogic Kafka connector, you should first load an instance of the [Kafka Datagen connector]
+(https://github.com/confluentinc/kafka-connect-datagen). The Datagen connector is a Kafka source connector that can
+generate test data which can then be fed to the MarkLogic Kafka connector. The following Gradle command will automate
+loading an instance of the Datagen connector that will write JSON messages to a `purchases` topic every second:
+
+    ./gradlew loadDatagenPurchasesConnector
+
+In the Control Center GUI, you can verify the Datagen connector instance:
+
+1. Click on "Connect" in the left sidebar
+2. Click on the "connect-default" cluster
+3. Click on the "datagen-purchases" connector
+
+Additionally, you can examine the data sent by the Datagen connector to the `purchases` topic:
+
+1. Click on "Topics" in the left sidebar
+2. Click on the "purchases" topic
+3. Click on "Messages" to see the JSON documents being sent by the connector
+
+## Load a MarkLogic Kafka connector instance
+
+Next, load an instance of the MarkLogic Kafka connector that will read data from the `purchases` topic and write
+it to MarkLogic. The `src/test/resources/confluent/marklogic-purchases-connector.json` file defines the connection
+properties for MarkLogic, and it defaults to writing to the `Documents` database via port 8000. You can adjust this file
+to suit your testing needs.
+
+    ./gradlew loadMarkLogicPurchasesConnector
+
+In the Control Center GUI, you can verify the MarkLogic Kafka connector instance:
+
+1. Click on "Connect" in the left sidebar
+2. Click on the "connect-default" cluster
+3. Click on the "marklogic-purchases" connector
+
+You can then verify that data is being written to MarkLogic by using MarkLogic's qconsole application to inspect the
+contents of the `Documents` database.
+
+You can also manually configure an instance of the MarkLogic Kafka connector as well:
+
+1. Click on "Connect" in the left sidebar
+2. Click on the "connect-default" cluster
+3. Click on "Add connector"
+4. Click on "MarkLogicSinkConnector"
+5. Select the topic(s) you wish to read from
+6. For "Key converter class" and "Value converter class", enter `org.apache.kafka.connect.storage.StringConverter`
+7. Under "General", enter values for the required MarkLogic connection fields and for any optional fields you wish
+   to configure
+8. At the bottom of the page, click "Next"
+9. Click "Launch"
+
+In the list of connectors in Control Center, the connector will initially have a status of "Failed" while it starts up.
+After it starts successfully, it will have a status of "Running". 
+
+## Destroying and setting up the Confluent Platform instance
+
+While developing and testing the MarkLogic Kafka connector, it is common that the "local" instance of Confluent 
+Platform will become unstable and no longer work. The [Confluent local docs](https://docs.confluent.io/confluent-cli/current/command-reference/local/confluent_local_current.html) 
+make reference to this - "The data that are produced are transient and are intended to be temporary". 
+
+It is thus advisable that after you copy a new instance of the MarkLogic Kafka connector into Confluent Platform (i.e. 
+by running `./gradlew copyConnectorToConfluent`), you should destroy your local Confluent Platform instance:
+
+    ./gradlew destroyLocalConfluent
+
+After doing that, you can quickly automate starting Confluent Platform and loading the two connectors via the following:
+
+    ./gradlew setupLocalConfluent
+
+Remember that if you've modified the connector code, you'll first need to run `./gradlew copyConnectorToConfluent`. 
+
+Doing the above will provide the most reliable way to get a new and working instance of Confluent Platform with the 
+MarkLogic Kafka connector installed.
+
+You may have luck with simply doing `confluent local services stop`, `./gradlew copyConnectorToConfluent`, and 
+`confluent local services start`, but this has so far not worked reliably - i.e. one of the Confluent Platform 
+services (sometimes Schema Registry, sometimes Control Center) usually stops working. 
+
+# Testing with Apache Kafka
+
+TODO, will borrow a lot of content from the README.

--- a/README.md
+++ b/README.md
@@ -1,24 +1,36 @@
-# kafka-connect-marklogic
+# MarkLogic Kafka connector
 
-This is a connector for subscribing to Kafka queues and pushing messages to MarkLogic
+The MarkLogic Kafka connector is a [Kafka Connect](https://docs.confluent.io/platform/current/connect/index.html) 
+sink connector for receiving messages from Kafka topics and writing them to a MarkLogic database. 
 
 ## Requirements
+
 * MarkLogic 9
 
-## Quick Start
+## Quick Start with Confluent Platform
 
-#### To try this out locally:
+TODO, will borrow some content from the CONTRIBUTING file
 
-1. Configure kafkaHome in gradle-local.properties - e.g. kafkaHome=/Users/myusername/tools/kafka_2.11-2.1.0
-1. Run "./gradlew clean deploy" to build a jar and copy it and the below property files into the appropriate Kafka directories
+## Quick Start with Apache Kafka
 
-#### To try this out on a remote Kafka server
-1. Run "./gradlew clean jar" to build the jar.
-1. Copy the jar to the <kafkaHome>/libs on the remote server.
-1. Copy the two properties (config/marklogic-connect-distributed.properties config/marklogic-sink.properties) to <kafkaHome>/config on the remote server.
+These instructions assume that you already have an instance of Apache Kafka installed; the [Kafka Quickstart]
+(https://kafka.apache.org/quickstart) instructions provide an easy way of accomplishing this. Perform step 1 of these
+instructions before proceeding.
 
-See https://kafka.apache.org/quickstart for instructions on starting up Zookeeper and Kafka, which as of August 2022 
-will instruct you to run the following commands (in separate terminal windows, both from the Kafka home directory):
+Next, if you are running Kafka locally, do the following:
+
+1. Configure `kafkaHome` in gradle-local.properties - e.g. kafkaHome=/Users/myusername/kafka_2.13-2.8.1
+1. Run `./gradlew clean deploy` to build a jar and copy it and the below property files into the appropriate Kafka directories
+
+If you are running Kafka on a remote server, do the following:
+
+1. Run `./gradlew clean shadowJar` to build the jar
+1. Copy the jar to the <kafkaHome>/libs on the remote server
+1. Copy the two properties (config/marklogic-connect-distributed.properties config/marklogic-sink.properties) to <kafkaHome>/config on the remote server
+
+See step 2 in the [Kafka Quickstart guide](https://kafka.apache.org/quickstart) for instructions on starting 
+Zookeeper and Kafka. As of August 2022, the guide will instruct you to run the following commands (in separate 
+terminal windows, both from the Kafka home directory):
 
     bin/zookeeper-server-start.sh config/zookeeper.properties
 
@@ -26,13 +38,13 @@ and:
 
     bin/kafka-server-start.sh config/server.properties
 
-To start the Kafka connector in standalone mode (from the Kafka home directory):
+Next, start the Kafka connector in standalone mode (also from the Kafka home directory):
 
     bin/connect-standalone.sh config/marklogic-connect-standalone.properties config/marklogic-sink.properties
 
 You'll see a fair amount of logging from Kafka itself; near the end of the logging, look for messages from 
-MarkLogicSinkTask and the Data Movement classes such as WriteBatcherImpl to ensure that the connector has started up
-correctly.
+`MarkLogicSinkTask` and MarkLogic Java Client classes such as `WriteBatcherImpl` to ensure that the connector has 
+started up correctly.
 
 You can also start the connector in distributed mode:
 

--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,6 @@ dependencies {
   assets files('apache_logo.png')
 }
 
-// Needed by Gradle 4.6+ - see https://www.petrikainulainen.net/programming/testing/junit-5-tutorial-running-unit-tests-with-gradle/
 test {
   useJUnitPlatform()
 }
@@ -88,73 +87,105 @@ task deploy {
   dependsOn = ["copyJarToKafka", "copyPropertyFilesToKafka"]
 }
 
+ext {
+  confluentArchiveGroup = "Confluent Connector Archive"
+  confluentTestingGroup = "Confluent Platform Local Testing"
+  baseArchiveBuildDir = "build/connectorArchive"
+  baseArchiveName = "${componentOwner}-${componentName}-${version}"
+}
+
 // Tasks for building the archive required for submitting to the Confluence Connector Hub
 
 import org.apache.tools.ant.filters.ReplaceTokens
 
-def baseArchiveBuildDir = "build/connectorArchive"
-def baseArchiveName = "${componentOwner}-${componentName}-${version}"
-task connectorArchive_CopyManifestToBuildDirectory(type: Copy) {
+task connectorArchive_CopyManifestToBuildDirectory(type: Copy, group: confluentArchiveGroup) {
   description = "Copy the project manifest into the root folder"
-  group = 'connector archive'
-
   from '.'
   include 'manifest.json'
   into "${baseArchiveBuildDir}/${baseArchiveName}"
   filter(ReplaceTokens, tokens: [CONFLUENT_USER: componentOwner, VERSION: version])
 }
 
-task connectorArchive_CopyAssetsToBuildDirectory(type: Copy) {
+task connectorArchive_CopyAssetsToBuildDirectory(type: Copy, group: confluentArchiveGroup) {
   description = "Copy the project assets into the assets folder"
-  group = 'connector archive'
-
   from configurations.assets
   into "${baseArchiveBuildDir}/${baseArchiveName}/assets"
 }
 
-task connectorArchive_CopyEtcToBuildDirectory(type: Copy) {
+task connectorArchive_CopyEtcToBuildDirectory(type: Copy, group: confluentArchiveGroup) {
   description = "Copy the project support files into the etc folder"
-  group = 'connector archive'
-
   from 'config'
   include '*'
   into "${baseArchiveBuildDir}/${baseArchiveName}/etc"
 }
 
-task connectorArchive_CopyDocumentationToBuildDirectory(type: Copy) {
+task connectorArchive_CopyDocumentationToBuildDirectory(type: Copy, group: confluentArchiveGroup) {
   description = "Copy the project documentation into the doc folder"
-  group = 'connector archive'
-
   from configurations.documentation
   into "${baseArchiveBuildDir}/${baseArchiveName}/doc"
 }
 
-task connectorArchive_CopyDependenciesToBuildDirectory(type: Copy) {
+task connectorArchive_CopyDependenciesToBuildDirectory(type: Copy, group: confluentArchiveGroup, dependsOn: jar) {
   description = "Copy the dependency jars into the lib folder"
-  group = 'connector archive'
-  dependsOn = [jar]
-
   from jar
   from configurations.runtimeClasspath.findAll { it.name.endsWith('jar') }
   into "${baseArchiveBuildDir}/${baseArchiveName}/lib"
 }
 
-task connectorArchive_BuildDirectory() {
+task connectorArchive_BuildDirectory(group: confluentArchiveGroup) {
   description = "Build the directory that will be used to create the Kafka Connector Archive"
-  dependsOn = [connectorArchive_CopyManifestToBuildDirectory,
-               connectorArchive_CopyDependenciesToBuildDirectory,
-               connectorArchive_CopyDocumentationToBuildDirectory,
-               connectorArchive_CopyEtcToBuildDirectory,
-               connectorArchive_CopyAssetsToBuildDirectory]
-  group = 'connector archive'
+  dependsOn = [
+    connectorArchive_CopyManifestToBuildDirectory,
+    connectorArchive_CopyDependenciesToBuildDirectory,
+    connectorArchive_CopyDocumentationToBuildDirectory,
+    connectorArchive_CopyEtcToBuildDirectory,
+    connectorArchive_CopyAssetsToBuildDirectory
+  ]
 }
 
-task connectorArchive(type: Zip, dependsOn: connectorArchive_BuildDirectory) {
+task connectorArchive(type: Zip, dependsOn: connectorArchive_BuildDirectory, group: confluentArchiveGroup) {
   description = 'Build a Connector Hub for the Confluent Connector Hub'
-  group = 'connector archive'
-
   from "${baseArchiveBuildDir}"
   include '**/*'
   archiveName "${baseArchiveName}.zip"
   destinationDir(file('build/distro'))
 }
+
+task copyConnectorToConfluent(type: Copy, group: confluentTestingGroup, dependsOn: connectorArchive_BuildDirectory) {
+  description = "Build the connector archive and copy it to your local Confluent Platform"
+  from baseArchiveBuildDir
+  into "${confluentHome}/share/confluent-hub-components"
+}
+
+// See https://docs.confluent.io/confluent-cli/current/command-reference/local/confluent_local_destroy.html
+task destroyLocalConfluent(type: Exec, group: confluentTestingGroup) {
+  description = "Destroy the local Confluent Platform instance"
+  commandLine "confluent", "local", "destroy"
+}
+
+// See https://docs.confluent.io/confluent-cli/current/command-reference/local/services/confluent_local_services_start.html
+task startLocalConfluent(type: Exec, group: confluentTestingGroup) {
+  description = "Convenience task for starting a local instance of Confluent Platform"
+  commandLine "confluent", "local", "services", "start"
+}
+
+task loadDatagenPurchasesConnector(type: Exec, group: confluentTestingGroup) {
+  description = "Load an instance of the Datagen connector into Confluent Platform for sending JSON documents to " +
+    "the 'purchases' topic"
+  commandLine "confluent", "local", "services", "connect", "connector", "load", "datagen-purchases", "-c",
+    "src/test/resources/confluent/datagen-purchases-connector.json"
+}
+
+task loadMarkLogicPurchasesConnector(type: Exec, group: confluentTestingGroup) {
+  description = "Load an instance of the MarkLogic Kafka connector into Confluent Platform for writing data to " +
+    "MarkLogic from the 'purchases' topic"
+  commandLine "confluent", "local", "services", "connect", "connector", "load", "marklogic-purchases", "-c",
+    "src/test/resources/confluent/marklogic-purchases-connector.json"
+}
+
+task setupLocalConfluent(group: confluentTestingGroup) {
+  description = "Start a local Confluent Platform instance and load the Datagen and MarkLogic connectors"
+}
+setupLocalConfluent.dependsOn startLocalConfluent, loadDatagenPurchasesConnector, loadMarkLogicPurchasesConnector
+loadDatagenPurchasesConnector.mustRunAfter startLocalConfluent
+loadMarkLogicPurchasesConnector.mustRunAfter startLocalConfluent

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,5 +5,8 @@ version=1.7.0-SNAPSHOT
 componentOwner=marklogic
 componentName=kafka-marklogic-connector
 
-# Override this in gradle-local.properties
+# Override in gradle-local.properties if testing with regular Apache Kafka
 kafkaHome=
+
+# Override in gradle-local.properties if testing with Confluent Platform
+confluentHome=

--- a/src/test/resources/confluent/datagen-purchases-connector.json
+++ b/src/test/resources/confluent/datagen-purchases-connector.json
@@ -1,0 +1,14 @@
+{
+  "name": "datagen-purchases",
+  "config": {
+    "connector.class": "io.confluent.kafka.connect.datagen.DatagenConnector",
+    "kafka.topic": "purchases",
+    "quickstart": "purchases",
+    "key.converter": "org.apache.kafka.connect.storage.StringConverter",
+    "value.converter": "org.apache.kafka.connect.json.JsonConverter",
+    "value.converter.schemas.enable": "false",
+    "value.converter.decimal.format": "NUMERIC",
+    "max.interval": 1000,
+    "tasks.max": "1"
+  }
+}

--- a/src/test/resources/confluent/marklogic-purchases-connector.json
+++ b/src/test/resources/confluent/marklogic-purchases-connector.json
@@ -1,0 +1,17 @@
+{
+  "name": "marklogic-purchases",
+  "config": {
+    "topics": "purchases",
+    "connector.class": "com.marklogic.kafka.connect.sink.MarkLogicSinkConnector",
+    "key.converter": "org.apache.kafka.connect.storage.StringConverter",
+    "value.converter": "org.apache.kafka.connect.storage.StringConverter",
+    "tasks.max": "1",
+    "ml.connection.host": "localhost",
+    "ml.connection.port": 8000,
+    "ml.connection.username": "admin",
+    "ml.connection.password": "admin",
+    "ml.connection.securityContextType": "DIGEST",
+    "ml.document.format": "JSON",
+    "ml.document.uriSuffix": ".json"
+  }
+}


### PR DESCRIPTION
Before 1.7.0 is released, the CONTRIBUTING guide will be updated to capture how to develop and test with regular Kafka. And the README will be updated to focus on using a connector release in both Kafka and Confluent. 