### PR TITLE
Reworked docs for config options

### DIFF
--- a/AWS-CloudFormation/s3Resources/marklogic-sink.properties
+++ b/AWS-CloudFormation/s3Resources/marklogic-sink.properties
@@ -2,105 +2,21 @@
 
 name=marklogic-sink
 connector.class=com.marklogic.kafka.connect.sink.MarkLogicSinkConnector
-
-# Should only need one task since it's using a WriteBatcher, which is multi-threaded
 tasks.max=1
-
 # Topics to consume from [comma separated list for multiple topics]
 topics=marklogic
 
-
 # MarkLogic connector-specific properties
+# See ./config/marklogic-sink.properties for information on each of these
 
-# A MarkLogic host to connect to. The connector uses the Data Movement SDK, and thus it will connect to each of the
-# hosts in a cluster.
 ml.connection.host=172.31.48.57
-
-# The port of a REST API server to connect to.
 ml.connection.port=8003
-
-# Optional - the name of a database to connect to. If your REST API server has a content database matching that of the
-# one that you want to write documents to, you do not need to set this.
 ml.connection.database=Kafka
-
-# Optional - set to "gateway" when using a load balancer, else leave blank.
-# See https://docs.marklogic.com/guide/java/data-movement#id_26583 for more information.
-ml.connection.type=
-
-# Either DIGEST, BASIC, CERTIFICATE, KERBEROS, or NONE
 ml.connection.securityContextType=DIGEST
-
-# Set these based on the security context type defined above
 ml.connection.username=admin
 ml.connection.password=admin
-ml.connection.certFile=
-ml.connection.certPassword=
-ml.connection.externalName=
-
-# Set "ml.connection.simpleSsl" to "true" for a "simple" SSL strategy that uses the JVM's default SslContext and
-# X509TrustManager and a "trust everything" HostnameVerifier. Further customization of an SSL connection via properties
-# is not supported. If you need to do so, consider using the source code for this connector as a starting point.
-ml.connection.simpleSsl=false
-# You must also ensure that the server cert or the signing CA cert is imported in the JVMs cacerts file.
-# These commands may be used to get the server cert and to import it into your cacerts file.
-# Don't forget to customize the commands for your particular case.
-#   openssl x509 -in <(openssl s_client -connect <server>:8004 -prexit 2>/dev/null) -out ~/example.crt
-#   sudo keytool -importcert -file ~/example.crt -alias <server> -keystore /path/to/java/lib/security/cacerts -storepass <storepass-password>
-
-# Sets the number of documents to be written in a batch to MarkLogic. This may not have any impact depending on the
-# connector receives data from Kafka, as the connector calls flushAsync on the DMSDK WriteBatcher after processing every
-# collection of records. Thus, if the connector never receives at one time more than the value of this property, then
-# the value of this property will have no impact.
-ml.dmsdk.batchSize=100
-
-# Sets the number of threads used by the Data Movement SDK for parallelizing writes to MarkLogic. Similar to the batch
-# size property above, this may never come into play depending on how many records the connector receives at once.
-ml.dmsdk.threadCount=8
-
-# Optional - a comma-separated list of collections that each document should be written to
 ml.document.collections=kafka-data
-
-# Optional - set this to true so that the name of the topic that the connector reads from is added as a collection to each document inserted by the connector
-ml.document.addTopicToCollections=false
-
-# Optional - specify the format of each document; either JSON, XML, BINARY, TEXT, or UNKNOWN
 ml.document.format=JSON
-
-# Optional - specify a mime type for each document; typically the format property above will be used instead of this
-ml.document.mimeType=
-
-# Optional - a comma-separated list of roles and capabilities that define the permissions for each document written to MarkLogic
 ml.document.permissions=rest-reader,read,rest-writer,update
-
-# Optional - a prefix to prepend to each URI; the URI itself is a UUID
 ml.document.uriPrefix=/kafka-data/
-
-# Optional - a suffix to append to each URI
 ml.document.uriSuffix=.json
-
-# Optional - name of a REST transform to use when writing documents
-# For Data Hub, can use mlRunIngest
-ml.dmsdk.transform=
-
-# Optional - delimited set of transform names and values
-# Data Hub example = flow-name,ingestion_mapping_mastering-flow,step,1
-ml.dmsdk.transformParams=
-
-# Optional - delimiter for transform parameter names and values
-ml.dmsdk.transformParamsDelimiter=,
-
-# Properties for running a Data Hub flow
-# Using examples/dh-5-example in the DH project, could use the following config:
-# ml.datahub.flow.name=ingestion_mapping_mastering-flow
-# ml.datahub.flow.steps=2,3,4
-ml.datahub.flow.name=
-ml.datahub.flow.steps=
-# Whether or not the response data from running a flow should be logged at the info level
-ml.datahub.flow.logResponse=true
-
-ml.id.strategy=
-ml.id.strategy.paths=
-ml.connection.enableCustomSsl=false
-ml.connection.customSsl.tlsVersion=
-ml.connection.customSsl.hostNameVerifier=
-ml.connection.customSsl.mutualAuth=false

--- a/README.md
+++ b/README.md
@@ -3,104 +3,107 @@
 The MarkLogic Kafka connector is a [Kafka Connect](https://docs.confluent.io/platform/current/connect/index.html) 
 sink connector for receiving messages from Kafka topics and writing them to a MarkLogic database. 
 
+This page describes how to obtain the MarkLogic Kafka connector and use with either Confluent Platform or Apache Kafka.
+For developing and testing the MarkLogic Kafka connector, please see the [guide on contributing](./CONTRIBUTING.md).
+That guide also includes detailed instructions on how to use both Confluent Platform and Apache Kafka which may be 
+useful if you are new to either product. 
+
 ## Requirements
 
-* MarkLogic 9
+* MarkLogic 9 or higher
+* Kafka 2.5 or higher, or Confluent Platform 7 or higher
 
-## Quick Start with Confluent Platform
+The MarkLogic Kafka connector may work on versions of Kafka prior to 2.5 or Confluent Platform prior to 7, but it has 
+not been tested on those. 
 
-TODO, will borrow some content from the CONTRIBUTING file
+## Using the connector with Confluent Platform
 
-## Quick Start with Apache Kafka
+[Confluent Platform](https://docs.confluent.io/platform/current/platform.html) provides an easy mechanism for running
+Kafka via a single platform, which includes a simple process for installing new connectors. 
 
-These instructions assume that you already have an instance of Apache Kafka installed; the [Kafka Quickstart]
-(https://kafka.apache.org/quickstart) instructions provide an easy way of accomplishing this. Perform step 1 of these
-instructions before proceeding.
+The MarkLogic Kafka connector can be installed via the instructions at 
+[Confluent Hub](https://www.confluent.io/hub/marklogic/kafka-marklogic-connector). After installing it, you can use 
+[Confluent Control Center](https://docs.confluent.io/platform/current/control-center/index.html) to load and configure
+as many instances of the MarkLogic Kafka connector that you wish. See the section below on configuring the connector for
+a list of available properties.
 
-Next, if you are running Kafka locally, do the following:
+## Using the connector with Apache Kafka
 
-1. Configure `kafkaHome` in gradle-local.properties - e.g. kafkaHome=/Users/myusername/kafka_2.13-2.8.1
-1. Run `./gradlew clean deploy` to build a jar and copy it and the below property files into the appropriate Kafka directories
+For a regular installation of Apache Kafka, obtain the latest version of the MarkLogic Kafka connector from 
+[this repository's Releases page](https://github.com/marklogic-community/kafka-marklogic-connector/releases). Download
+the jar file - named `kafka-connect-marklogic-(version).jar` - and copy it to the `./libs` directory in your Kafka 
+distribution. 
 
-If you are running Kafka on a remote server, do the following:
+Next, copy the `config/marklogic-connect-standalone.properties` and `config/marklogic-sink.properties` files in this 
+repository to the `./config` directory in your Kafka distribution. Modify these properties as necessary; a 
+description of each can be found below. 
 
-1. Run `./gradlew clean shadowJar` to build the jar
-1. Copy the jar to the <kafkaHome>/libs on the remote server
-1. Copy the two properties (config/marklogic-connect-distributed.properties config/marklogic-sink.properties) to <kafkaHome>/config on the remote server
-
-See step 2 in the [Kafka Quickstart guide](https://kafka.apache.org/quickstart) for instructions on starting 
-Zookeeper and Kafka. As of August 2022, the guide will instruct you to run the following commands (in separate 
-terminal windows, both from the Kafka home directory):
-
-    bin/zookeeper-server-start.sh config/zookeeper.properties
-
-and: 
-
-    bin/kafka-server-start.sh config/server.properties
-
-Next, start the Kafka connector in standalone mode (also from the Kafka home directory):
-
-    bin/connect-standalone.sh config/marklogic-connect-standalone.properties config/marklogic-sink.properties
-
-You'll see a fair amount of logging from Kafka itself; near the end of the logging, look for messages from 
-`MarkLogicSinkTask` and MarkLogic Java Client classes such as `WriteBatcherImpl` to ensure that the connector has 
-started up correctly.
-
-You can also start the connector in distributed mode:
-
-    bin/connect-distributed.sh config/marklogic-connect-distributed.properties config/marklogic-sink.properties
-
-The default topic is "marklogic", so to send some messages to that topic, run the following:
-
-    bin/kafka-console-producer.sh --broker-list localhost:9092 --topic marklogic
-
-Be sure that the messages you send are consistent with your configuration properties - i.e. if you've set a format of 
-JSON, you should send properly formed JSON objects.
-
-When a document is received and written by the connector, you'll see logging like this:
-
-```
-[2018-12-20 12:54:13,561] INFO flushing 1 queued docs (com.marklogic.client.datamovement.impl.WriteBatcherImpl:549)
-```
+You can then start up a [Kafka Connect](https://docs.confluent.io/platform/current/connect/index.html) process. Kafka
+Connect will instantiate the MarkLogic Kafka connector based on the configuration in the files above. 
 
 ## Configuring the connector
 
-#### Connector-specific properties are defined in config/marklogic-connect-standalone.properties
+### Common Kafka connector properties
+
+Common Kafka connector properties are defined via the `config/marklogic-connect-standalone.properties` file. 
+
 | Property | Default Value | Description |
 |:-------- |:--------------|:------------|
-| bootstrap.servers              | 9092                                             | This points to the Kafka server and port                                                                                                                                      |
-| key.converter                  | org.apache.kafka.connect.storage.StringConverter | This controls the format of the data that will be written to Kafka for source connectors or read from Kafka for sink connectors.                                              |
-| value.converter                | org.apache.kafka.connect.storage.StringConverter | This controls the format of the data that will be written to Kafka for source connectors or read from Kafka for sink connectors.                                              |
-| key.converter.schemas.enable   | false                                            | Control the use of schemas for keys                                                                                                                                           |
-| value.converter.schemas.enable | false                                            | Control the use of schemas for values                                                                                                                                         |
-| offset.storage.file.filename   | /tmp/connect.offsets                             | The file to store connector offsets in. By storing offsets on disk, a standalone process can be stopped and started on a single node and resume where it previously left off. |
-| offset.flush.interval.ms       | 10000                                            | Interval at which to try committing offsets for tasks.                                                                                                                        |
+| bootstrap.servers  | 9092  | Points to the Kafka server and port |
+| key.converter | org.apache.kafka.connect.storage.StringConverter | Controls the format of the data that will be written to Kafka for source connectors or read from Kafka for sink connectors. |
+| value.converter  | org.apache.kafka.connect.storage.StringConverter | Controls the format of the data that will be written to Kafka for source connectors or read from Kafka for sink connectors. |
+| key.converter.schemas.enable  | false | Controls the use of schemas for keys |
+| value.converter.schemas.enable | false | Controls the use of schemas for values |
+| offset.storage.file.filename   | /tmp/connect.offsets | The file to store connector offsets in. By storing offsets on disk, a standalone process can be stopped and started on a single node and resume where it previously left off. |
+| offset.flush.interval.ms  | 10000  | Interval at which to try committing offsets for tasks. |
 
-#### MarkLogic-specific properties are defined in config/marklogic-sink.properties
-| Property                          | Default Value                                                      | Description |
-|:----------------------------------|:-------------------------------------------------------------------|:------------|
-| name                              | marklogic-sink                                                     | The name of the connector |
-| connector.class                   | <div>com.marklogic.kafka.connect.</div>sink.MarkLogicSinkConnector | The FQ name of the connector class |
-| tasks.max                         | 1                                                                  | The maximum number of concurrent tasks |
-| topics                            | marklogic                                                          | The name of the topic(s) to subscribe to |
-| ml.connection.host                | localhost                                                          | A MarkLogic host to connect to. The connector uses the Data Movement SDK, and thus it will connect to each of the hosts in a cluster. |
-| ml.connection.port                | 8000                                                               | The port of a REST API server to connect to. |
-| ml.connection.database            | Documents                                                          | Optional - the name of a database to connect to. If your REST API server has a content database matching that of the one that you want to write documents to, you do not need to set this. |
-| ml.connection.type                | (empty)                                                            | Optional - set to "gateway" when using a load balancer, else leave blank. See https://docs.marklogic.com/guide/java/data-movement#id_26583 for more information. |
-| ml.connection.securityContextType | DIGEST                                                             | Either DIGEST, BASIC, CERTIFICATE, KERBEROS, or NONE |
-| ml.connection.username            | admin                                                              | MarkLogic username |
-| ml.connection.password            | admin                                                              | MarkLogic password |
-| ml.connection.certFile            | (empty)                                                            | Certificate file for Certificate based authentication |
-| ml.connection.certPassword        | (empty)                                                            | Certificate password for Certificate based authentication |
-| ml.connection.externalName        | (empty)                                                            | The external name to use to connect to MarkLogic |
-| ml.connection.simpleSsl           | false                                                              | Set to "true" for a "simple" SSL strategy that uses the JVM's default SslContext and X509TrustManager and a "trust everything" HostnameVerifier. Further customization of an SSL connection via properties is not supported. If you need to do so, consider using the source code for this connector as a starting point. |
-| ml.dmsdk.batchSize                | 100                                                                | Sets the number of documents to be written in a batch to MarkLogic. This may not have any impact depending on the connector receives data from Kafka, as the connector calls flushAsync on the DMSDK WriteBatcher after processing every collection of records. Thus, if the connector never receives at one time more than the value of this property, then the value of this property will have no impact. |
-| ml.dmsdk.threadCount              | 8                                                                  | Sets the number of threads used by the Data Movement SDK for parallelizing writes to MarkLogic. Similar to the batch size property above, this may never come into play depending on how many records the connector receives at once. |
-| ml.document.collections           | kafka-data                                                         | Optional - a comma-separated list of collections that each document should be written to |
-| ml.document.addTopicToCollections | false                                                              | Set this to true so that the name of the topic that the connector reads from is added as a collection to each document inserted by the connector |
-| ml.document.temporalCollection    | (empty)                                                            | Specify the name of a temporal collection for documents to be inserted into |
-| ml.document.format                | JSON                                                               | Optional - specify the format of each document; either JSON, XML, BINARY, TEXT, or UNKNOWN |
-| ml.document.mimeType              | (empty)                                                            | Optional - specify a mime type for each document; typically the format property above will be used instead of this |
-| ml.document.permissions           | rest-reader,read,rest-writer,update                                | Optional - a comma-separated list of roles and capabilities that define the permissions for each document written to MarkLogic |
-| ml.document.uriPrefix             | /kafka-data/                                                       | Optional - a prefix to prepend to each URI; the URI itself is a UUID |
-| ml.document.uriSuffix             | .json                                                              | Optional - a suffix to append to each URI |
+### MarkLogic Kafka connector properties
+
+Properties specific to the MarkLogic Kafka connector are defined via the `config/marklogic-sink.properties` file.
+
+The default values in the table below are enforced by the connector. The `config/marklogic-sink.properties` file 
+included in this repository defines values for additional properties for the sole purpose of simplifying testing of the 
+connector.
+
+| Property | Default Value  | Description |
+|:---------|:------------|:---------------|
+| name | marklogic-sink | The name of the connector |
+| connector.class | <div>com.marklogic.kafka.</div><div>connect.sink.</div>MarkLogicSinkConnector | The fully-qualified name of the connector class |
+| tasks.max | 1 | The maximum number of concurrent tasks |
+| topics | marklogic | Comma-separated list of topics to subscribe to |
+| ml.connection.host | | Required; a MarkLogic host to connect to. By default, the connector uses the Data Movement SDK, and thus it will connect to each of the hosts in a cluster.|
+| ml.connection.port | | Required; the port of a REST API server to connect to |
+| ml.connection.securityContextType | DIGEST | Required; the authentication scheme used by the server defined by ml.connection.port; either 'DIGEST', 'BASIC', 'CERTIFICATE', 'KERBEROS', or 'NONE' |
+| ml.connection.username | | MarkLogic username for 'DIGEST' and 'BASIC' authentication |
+| ml.connection.password | | MarkLogic password for 'DIGEST' and 'BASIC' authentication |
+| ml.connection.certFile | | Path to PKCS12 file for 'CERTIFICATE' authentication |
+| ml.connection.certPassword | | Password for PKCS12 file for 'CERTIFICATE' authentication |
+| ml.connection.externalName | | External name for 'KERBEROS' authentication |
+| ml.connection.database | | Name of a database to connect to. If your REST API server has a content database matching that of the one that you want to write documents to, you do not need to set this. |
+| ml.connection.type | | Set to 'GATEWAY' when the host identified by ml.connection.host is a load balancer. See https://docs.marklogic.com/guide/java/data-movement#id_26583 for more information. |
+| ml.connection.simpleSsl | false | Set to 'true' for a simple SSL strategy that uses the JVM's default SslContext and X509TrustManager and an 'any' host verification strategy |
+| ml.connection.enableCustomSsl | false | Set to 'true' to customize how an SSL connection is created. Only supported if securityContextType is 'BASIC' or 'DIGEST'. |
+| ml.connection.customSsl.tlsVersion | TLSv1.2 | The TLS version to use for custom SSL |
+| ml.connection.customSsl.hostNameVerifier | ANY | The host verification strategy for custom SSL; either 'ANY', 'COMMON', or 'STRICT' |
+| ml.connection.customSsl.mutualAuth | false | Set this to true for 2-way SSL; defaults to 1-way SSL |
+| ml.document.format | | Specify the format of each document; either 'JSON', 'XML', 'BINARY', 'TEXT', or 'UNKNOWN'. If not set, MarkLogic will determine the document type based on the ml.document.uriSuffix property. |
+| ml.document.collections | | Comma-separated list of collections that each document should be written to |
+| ml.document.permissions | | Comma-separated list of roles and capabilities that define the permissions for each document |
+| ml.document.uriPrefix | | Prefix to prepend to each URI; the URI itself is a UUID |
+| ml.document.uriSuffix | | Suffix to append to each URI; will determine the document type if ml.document.format is not set |
+| ml.document.temporalCollection | | Name of a temporal collection for documents to be inserted into |
+| ml.document.addTopicToCollections | false | Set this to true so that the name of the topic that the connector reads from is added as a collection to each document inserted by the connector |
+| ml.document.mimeType | | Specify a mime type for each document; typically ml.document.format will be used instead of this |
+| ml.id.strategy | | Set the strategy for generating a unique URI for each document written to MarkLogic. Defaults to 'UUID'. Other choices are: 'JSONPATH', 'HASH', 'KAFKA_META_HASHED', and 'KAFKA_META_WITH_SLASH'. |
+| ml.id.strategy.paths | | For use with 'JSONPATH' and 'HASH'; comma-separated list of paths for extracting values for the ID |
+| ml.dmsdk.batchSize | 100 | Sets the number of documents to be written in a batch to MarkLogic. This may not have any impact depending on how the connector receives data from Kafka. The connector calls flushAsync on the DMSDK WriteBatcher after processing every collection of records. Thus, if the connector never receives at one time more than the value of this property, then the value of this property will have no impact. |
+| ml.dmsdk.threadCount | 8 | Sets the number of threads used for parallel writes to MarkLogic. Similar to the batch size property above, this may never come into play depending on how many records the connector receives at once. |
+| ml.dmsdk.transform | | Name of a REST transform to use when writing documents |
+| ml.dmsdk.transformParams | | Delimited set of transform parameter names and values; example = param1,value1,param2,value2 |
+| ml.dmsdk.transformParamsDelimiter | , | Delimiter for transform parameter names and values |
+| ml.log.record.key | false | Set to true to log at the info level the key of each record |
+| ml.log.record.headers | false | Set to true to log at the info level the headers of each record | 
+| ml.datahub.flow.name | | Name of a Data Hub Framework flow to run after writing documents |
+| ml.datahub.flow.steps | | Comma-delimited list of step numbers in a flow to run |
+| ml.datahub.flow.logResponse | | Set to true to log at the info level the response data from running a flow |
+

--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ dependencies {
   }
 
   // 1.2.1 will be published soon, and then we'll switch to that
-  testImplementation 'com.marklogic:marklogic-junit5:1.2.1-SNAPSHOT'
+  testImplementation 'com.marklogic:marklogic-junit5:1.2.1'
 
   testImplementation "org.apache.kafka:connect-api:${kafkaVersion}"
   testImplementation "org.apache.kafka:connect-json:${kafkaVersion}"
@@ -87,6 +87,12 @@ task copyPropertyFilesToKafka(type: Copy) {
   description = "Used for local development and testing; copies the properties files to your local Kafka install"
   from "config"
   into "${kafkaHome}/config"
+  filter { String line ->
+    line.startsWith('ml.connection.username=') ? 'ml.connection.username=' + kafkaMlUsername : line
+  }
+  filter { String line ->
+    line.startsWith('ml.connection.password=') ? 'ml.connection.password=' + kafkaMlPassword : line
+  }
 }
 
 task deploy {

--- a/config/marklogic-sink.properties
+++ b/config/marklogic-sink.properties
@@ -1,113 +1,130 @@
-# Kafka-specific properties
+# Properties required for every Kafka connector
 
+# The name of the connector
 name=marklogic-sink
+
+# The fully-qualified name of the connector class
 connector.class=com.marklogic.kafka.connect.sink.MarkLogicSinkConnector
 
-# Should only need one task since it's using a WriteBatcher, which is multi-threaded
+# The maximum number of concurrent tasks
 tasks.max=1
 
-# Topics to consume from [comma separated list for multiple topics]
+# Comma-separated list of topics to subscribe to
 topics=marklogic
 
 
-# MarkLogic connector-specific properties
+# Properties defined by the MarkLogic Kafka connector
 
-# A MarkLogic host to connect to. The connector uses the Data Movement SDK, and thus it will connect to each of the
-# hosts in a cluster.
+# Required; a MarkLogic host to connect to. By default, the connector uses the Data Movement SDK, and thus it will
+# connect to each of the hosts in a cluster.
 ml.connection.host=localhost
 
-# The port of a REST API server to connect to.
+# Required; the port of a REST API server to connect to
 ml.connection.port=8000
 
-# Optional - the name of a database to connect to. If your REST API server has a content database matching that of the
-# one that you want to write documents to, you do not need to set this.
-ml.connection.database=Documents
-
-# Optional - set to "gateway" when using a load balancer, else leave blank.
-# See https://docs.marklogic.com/guide/java/data-movement#id_26583 for more information.
-ml.connection.type=
-
-# Either DIGEST, BASIC, CERTIFICATE, KERBEROS, or NONE
+# Required; the authentication scheme used by the server defined by ml.connection.port; either 'DIGEST', 'BASIC', 'CERTIFICATE', 'KERBEROS', or 'NONE'
 ml.connection.securityContextType=DIGEST
 
-# Set these based on the security context type defined above
-ml.connection.username=admin
-ml.connection.password=admin
-ml.connection.certFile=
-ml.connection.certPassword=
-ml.connection.externalName=
+# MarkLogic username for 'DIGEST' and 'BASIC' authentication
+ml.connection.username=
 
-# Set "ml.connection.simpleSsl" to "true" for a "simple" SSL strategy that uses the JVM's default SslContext and
-# X509TrustManager and a "trust everything" HostnameVerifier. Further customization of an SSL connection via properties
-# is not supported. If you need to do so, consider using the source code for this connector as a starting point.
-ml.connection.simpleSsl=false
+# MarkLogic password for 'DIGEST' and 'BASIC' authentication
+ml.connection.password=
+
+# Path to PKCS12 file for 'CERTIFICATE' authentication
+# ml.connection.certFile=
+# Password for PKCS12 file for 'CERTIFICATE' authentication
+# ml.connection.certPassword=
+
+# External name for 'KERBEROS' authentication
+# ml.connection.externalName=
+
+# Name of a database to connect to. If your REST API server has a content database matching that of the one that you
+# want to write documents to, you do not need to set this.
+# ml.connection.database=
+
+# Set to 'GATEWAY' when the host identified by ml.connection.host is a load balancer.
+# See https://docs.marklogic.com/guide/java/data-movement#id_26583 for more information.
+# ml.connection.type=
+
+# Set to 'true' for a simple SSL strategy that uses the JVM's default SslContext and X509TrustManager and an 'any' host verification strategy
+# ml.connection.simpleSsl=true
 # You must also ensure that the server cert or the signing CA cert is imported in the JVMs cacerts file.
 # These commands may be used to get the server cert and to import it into your cacerts file.
 # Don't forget to customize the commands for your particular case.
 #   openssl x509 -in <(openssl s_client -connect <server>:8004 -prexit 2>/dev/null) -out ~/example.crt
 #   sudo keytool -importcert -file ~/example.crt -alias <server> -keystore /path/to/java/lib/security/cacerts -storepass <storepass-password>
 
-# Sets the number of documents to be written in a batch to MarkLogic. This may not have any impact depending on the
-# connector receives data from Kafka, as the connector calls flushAsync on the DMSDK WriteBatcher after processing every
+# Set to 'true' to customize how an SSL connection is created. Only supported if securityContextType is 'BASIC' or 'DIGEST'.
+# ml.connection.enableCustomSsl=true
+# The TLS version to use for custom SSL
+# ml.connection.customSsl.tlsVersion=TLSv1.2
+# The host verification strategy for custom SSL; either 'ANY', 'COMMON', or 'STRICT'
+# ml.connection.customSsl.hostNameVerifier=ANY
+# Set this to true for 2-way SSL; defaults to 1-way SSL
+# ml.connection.customSsl.mutualAuth=true
+
+# Specify the format of each document; either 'JSON', 'XML', 'BINARY', 'TEXT', or 'UNKNOWN'.
+# If not set, MarkLogic will determine the document type based on the ml.document.uriSuffix property.
+ml.document.format=JSON
+
+# Comma-separated list of collections that each document should be written to
+ml.document.collections=kafka-data
+
+# Comma-separated list of roles and capabilities that define the permissions for each document
+ml.document.permissions=rest-reader,read,rest-writer,update
+
+# Prefix to prepend to each URI; the URI itself is a UUID
+ml.document.uriPrefix=/kafka-data/
+
+# Suffix to append to each URI; will determine the document type if ml.document.format is not set
+ml.document.uriSuffix=.json
+
+# Name of a temporal collection for documents to be inserted into
+# ml.document.temporalCollection=
+
+# Set this to true so that the name of the topic that the connector reads from is added as a collection to each
+# document inserted by the connector
+# ml.document.addTopicToCollections=true
+
+# Specify a mime type for each document; typically ml.document.format will be used instead of this
+# ml.document.mimeType=
+
+# Set the strategy for generating a unique URI for each document written to MarkLogic. Defaults to 'UUID'.
+# Other choices are: 'JSONPATH', 'HASH', 'KAFKA_META_HASHED', and 'KAFKA_META_WITH_SLASH'.
+# ml.id.strategy=
+
+# For use with JSONPATH and HASH; comma-separated list of paths for extracting values for the ID
+# ml.id.strategy.paths=
+
+# Sets the number of documents to be written in a batch to MarkLogic. This may not have any impact depending on how the
+# connector receives data from Kafka. The connector calls flushAsync on the DMSDK WriteBatcher after processing every
 # collection of records. Thus, if the connector never receives at one time more than the value of this property, then
 # the value of this property will have no impact.
 ml.dmsdk.batchSize=100
 
-# Sets the number of threads used by the Data Movement SDK for parallelizing writes to MarkLogic. Similar to the batch
-# size property above, this may never come into play depending on how many records the connector receives at once.
+# Sets the number of threads used for parallel writes to MarkLogic. Similar to the batch size property above, this
+# may never come into play depending on how many records the connector receives at once.
 ml.dmsdk.threadCount=8
 
-# Optional - a comma-separated list of collections that each document should be written to
-ml.document.collections=kafka-data
+# Name of a REST transform to use when writing documents
+# ml.dmsdk.transform=
 
-# Optional - set this to true so that the name of the topic that the connector reads from is added as a collection to each document inserted by the connector
-ml.document.addTopicToCollections=false
+# Delimited set of transform parameter names and values; example = param1,value1,param2,value2
+# ml.dmsdk.transformParams=
 
-# Specify the name of a temporal collection for documents to be inserted into
-ml.document.temporalCollection=
+# Delimiter for transform parameter names and values
+# ml.dmsdk.transformParamsDelimiter=,
 
-# Optional - specify the format of each document; either JSON, XML, BINARY, TEXT, or UNKNOWN
-ml.document.format=JSON
+# Set to true to log at the info level the key of each record
+# ml.log.record.key=true
 
-# Optional - specify a mime type for each document; typically the format property above will be used instead of this
-ml.document.mimeType=
+# Set to true to log at the info level the headers of each record
+# ml.log.record.headers=true
 
-# Optional - a comma-separated list of roles and capabilities that define the permissions for each document written to MarkLogic
-ml.document.permissions=rest-reader,read,rest-writer,update
-
-# Optional - a prefix to prepend to each URI; the URI itself is a UUID
-ml.document.uriPrefix=/kafka-data/
-
-# Optional - a suffix to append to each URI
-ml.document.uriSuffix=.json
-
-# Optional - name of a REST transform to use when writing documents
-# For Data Hub, can use mlRunIngest
-ml.dmsdk.transform=
-
-# Optional - delimited set of transform names and values
-# Data Hub example = flow-name,ingestion_mapping_mastering-flow,step,1
-ml.dmsdk.transformParams=
-
-# Optional - delimiter for transform parameter names and values
-ml.dmsdk.transformParamsDelimiter=,
-
-# Properties for running a Data Hub flow
-# Using examples/dh-5-example in the DH project, could use the following config:
-# ml.datahub.flow.name=ingestion_mapping_mastering-flow
-# ml.datahub.flow.steps=2,3,4
-ml.datahub.flow.name=
-ml.datahub.flow.steps=
-# Whether or not the response data from running a flow should be logged at the info level
-ml.datahub.flow.logResponse=true
-
-# Logging configurations
-ml.log.record.key=false
-ml.log.record.headers=false
-
-ml.id.strategy=
-ml.id.strategy.paths=
-ml.connection.enableCustomSsl=false
-ml.connection.customSsl.tlsVersion=
-ml.connection.customSsl.hostNameVerifier=
-ml.connection.customSsl.mutualAuth=false
+# Name of a Data Hub Framework flow to run after writing documents
+# ml.datahub.flow.name=
+# Comma-delimited list of step numbers in a flow to run
+# ml.datahub.flow.steps=
+# Set to true to log at the info level the response data from running a flow
+# ml.datahub.flow.logResponse=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,8 @@ componentName=kafka-marklogic-connector
 
 # Override in gradle-local.properties if testing with regular Apache Kafka
 kafkaHome=
+kafkaMlUsername=
+kafkaMlPassword=
 
 # Override in gradle-local.properties if testing with Confluent Platform
 confluentHome=

--- a/src/main/java/com/marklogic/kafka/connect/sink/MarkLogicSinkConfig.java
+++ b/src/main/java/com/marklogic/kafka/connect/sink/MarkLogicSinkConfig.java
@@ -43,7 +43,7 @@ public class MarkLogicSinkConfig extends AbstractConfig {
     public static final String DOCUMENT_URI_PREFIX = "ml.document.uriPrefix";
     public static final String DOCUMENT_URI_SUFFIX = "ml.document.uriSuffix";
 
-    public static final String SSL = "ml.connection.enableCustomSsl";
+    public static final String ENABLE_CUSTOM_SSL = "ml.connection.enableCustomSsl";
     public static final String TLS_VERSION = "ml.connection.customSsl.tlsVersion";
     public static final String SSL_HOST_VERIFIER = "ml.connection.customSsl.hostNameVerifier";
     public static final String SSL_MUTUAL_AUTH = "ml.connection.customSsl.mutualAuth";
@@ -55,44 +55,83 @@ public class MarkLogicSinkConfig extends AbstractConfig {
     public static final String ID_STRATEGY_PATH = "ml.id.strategy.paths";
 
     public static ConfigDef CONFIG_DEF = new ConfigDef()
-        .define(CONNECTION_HOST, Type.STRING, Importance.HIGH, "MarkLogic server hostname")
-        .define(CONNECTION_PORT, Type.INT, Importance.HIGH, "The REST app server port to connect to")
-        .define(CONNECTION_DATABASE, Type.STRING, "", Importance.LOW, "Database to connect, if different from the one associated with the port")
-        .define(CONNECTION_SECURITY_CONTEXT_TYPE, Type.STRING, "NONE", Importance.HIGH, "Type of MarkLogic security context to create - either digest, basic, kerberos, certificate, or none")
-        .define(CONNECTION_USERNAME, Type.STRING, null, Importance.HIGH, "Name of MarkLogic user to " +
-            "authenticate as")
-        .define(CONNECTION_PASSWORD, Type.PASSWORD, null, Importance.HIGH, "Password for the MarkLogic user")
-        .define(CONNECTION_TYPE, Type.STRING, "DIRECT", Importance.LOW, "Connection type; DIRECT or GATEWAY")
-        .define(CONNECTION_SIMPLE_SSL, Type.BOOLEAN, false, Importance.LOW, "Set to true to use a trust-everything SSL connection")
-        .define(CONNECTION_CERT_FILE, Type.STRING, "", Importance.LOW, "Path to a certificate file")
-        .define(CONNECTION_CERT_PASSWORD, Type.PASSWORD, null, Importance.LOW, "Password for the certificate file")
-        .define(CONNECTION_EXTERNAL_NAME, Type.STRING, "", Importance.LOW, "External name for Kerberos authentication")
-        .define(DATAHUB_FLOW_NAME, Type.STRING, null, Importance.MEDIUM, "Name of a Data Hub flow to run")
-        .define(DATAHUB_FLOW_STEPS, Type.STRING, null, Importance.MEDIUM, "Comma-delimited names of steps to run")
-        .define(DATAHUB_FLOW_LOG_RESPONSE, Type.BOOLEAN, false, Importance.LOW, "If set to true, the response from running a flow on each ingested batch will be logged at the info level")
-        .define(DMSDK_BATCH_SIZE, Type.INT, null, Importance.HIGH, "Number of documents to write in each batch")
-        .define(DMSDK_THREAD_COUNT, Type.INT, null, Importance.HIGH, "Number of threads for DMSDK to use")
-        .define(DMSDK_TRANSFORM, Type.STRING, null, Importance.MEDIUM, "Name of a REST transform to use when writing documents")
-        .define(DMSDK_TRANSFORM_PARAMS, Type.STRING, null, Importance.MEDIUM, "Delimited set of transform names and values")
-        .define(DMSDK_TRANSFORM_PARAMS_DELIMITER, Type.STRING, ",", Importance.LOW, "Delimiter for transform parameter names and values; defaults to a comma")
-        .define(DOCUMENT_COLLECTIONS_ADD_TOPIC, Type.BOOLEAN, false, Importance.LOW, "Indicates if the topic name should be added to the set of collections for a document")
-        .define(DOCUMENT_COLLECTIONS, Type.STRING, "", Importance.MEDIUM, "String-delimited collections to add each document to")
-        .define(DOCUMENT_TEMPORAL_COLLECTION, Type.STRING, null, Importance.LOW, "Specify the name of a temporal collection for documents to be inserted into")
-        .define(DOCUMENT_FORMAT, Type.STRING, "", Importance.LOW, "Defines format of each document; can be one of json, xml, text, binary, or unknown")
-        .define(DOCUMENT_MIMETYPE, Type.STRING, "", Importance.LOW, "Defines the mime type of each document; optional, and typically the format is set instead of the mime type")
-        .define(DOCUMENT_PERMISSIONS, Type.STRING, "", Importance.MEDIUM, "String-delimited permissions to add to each document; role1,capability1,role2,capability2,etc")
-        .define(DOCUMENT_URI_PREFIX, Type.STRING, "", Importance.MEDIUM, "Prefix to prepend to each generated URI")
-        .define(DOCUMENT_URI_SUFFIX, Type.STRING, "", Importance.MEDIUM, "Suffix to append to each generated URI")
-        .define(SSL, Type.BOOLEAN, false, Importance.LOW, "Whether SSL connection to the App server - true or false.")
-        .define(TLS_VERSION, Type.STRING, "", Importance.LOW, "Version of TLS to connect to MarkLogic SSL enabled App server. Ex. TLSv1.2")
-        .define(SSL_HOST_VERIFIER, Type.STRING, "", Importance.LOW, "The strictness of Host Verifier - ANY, COMMON, STRICT")
-        .define(SSL_MUTUAL_AUTH, Type.BOOLEAN, false, Importance.LOW, "Mutual Authentication for Basic or Digest : true or false")
+        .define(CONNECTION_HOST, Type.STRING, Importance.HIGH,
+            "Required; a MarkLogic host to connect to. By default, the connector uses the Data Movement SDK, and thus it will connect to each of the hosts in a cluster.")
+        .define(CONNECTION_PORT, Type.INT, Importance.HIGH,
+            "Required; the port of a REST API server to connect to")
+        .define(CONNECTION_SECURITY_CONTEXT_TYPE, Type.STRING, "DIGEST", Importance.HIGH,
+            "Required; the authentication scheme used by the server defined by ml.connection.port; either 'DIGEST', 'BASIC', 'CERTIFICATE', 'KERBEROS', or 'NONE'")
+        .define(CONNECTION_USERNAME, Type.STRING, null, Importance.MEDIUM,
+            "MarkLogic username for 'DIGEST' and 'BASIC' authentication")
+        .define(CONNECTION_PASSWORD, Type.PASSWORD, null, Importance.MEDIUM,
+            "MarkLogic password for 'DIGEST' and 'BASIC' authentication")
+        .define(CONNECTION_CERT_FILE, Type.STRING, null, Importance.MEDIUM,
+            "Path to PKCS12 file for 'CERTIFICATE' authentication")
+        .define(CONNECTION_CERT_PASSWORD, Type.PASSWORD, null, Importance.MEDIUM,
+            "Password for PKCS12 file for 'CERTIFICATE' authentication")
+        .define(CONNECTION_EXTERNAL_NAME, Type.STRING, null, Importance.MEDIUM,
+            "External name for 'KERBEROS' authentication")
+        .define(CONNECTION_DATABASE, Type.STRING, null, Importance.LOW,
+            "Name of a database to connect to. If your REST API server has a content database matching that of the one that you want to write documents to, you do not need to set this.")
+        .define(CONNECTION_TYPE, Type.STRING, null, Importance.MEDIUM,
+            "Set to 'GATEWAY' when the host identified by ml.connection.host is a load balancer. See https://docs.marklogic.com/guide/java/data-movement#id_26583 for more information.")
+        // Boolean fields must have a default value of null; otherwise, Confluent Platform, at least in version 7.2.1,
+        // will show a default value of "true"
+        .define(CONNECTION_SIMPLE_SSL, Type.BOOLEAN, null, Importance.LOW,
+            "Set to 'true' for a simple SSL strategy that uses the JVM's default SslContext and X509TrustManager and an 'any' host verification strategy")
+        .define(ENABLE_CUSTOM_SSL, Type.BOOLEAN, null, Importance.LOW,
+            "Set to 'true' to customize how an SSL connection is created. Only supported if securityContextType is 'BASIC' or 'DIGEST'.")
+        .define(TLS_VERSION, Type.STRING, "TLSv1.2", Importance.LOW,
+            "The TLS version to use for custom SSL")
+        .define(SSL_HOST_VERIFIER, Type.STRING, "ANY", Importance.LOW,
+            "The host verification strategy for custom SSL; either 'ANY', 'COMMON', or 'STRICT'")
+        .define(SSL_MUTUAL_AUTH, Type.BOOLEAN, null, Importance.LOW,
+            "Set this to true for 2-way SSL; defaults to 1-way SSL")
 
-        .define(LOGGING_RECORD_KEY, Type.BOOLEAN, false, Importance.LOW, "Log incoming record keys")
-        .define(LOGGING_RECORD_HEADERS, Type.BOOLEAN, false, Importance.LOW, "Log incoming record headers")
+        .define(DOCUMENT_FORMAT, Type.STRING, null, Importance.MEDIUM,
+            "Specify the format of each document; either 'JSON', 'XML', 'BINARY', 'TEXT', or 'UNKNOWN'. If not set, MarkLogic will determine the document type based on the ml.document.uriSuffix property.")
+        .define(DOCUMENT_COLLECTIONS, Type.STRING, null, Importance.MEDIUM,
+            "Comma-separated list of collections that each document should be written to")
+        .define(DOCUMENT_PERMISSIONS, Type.STRING, null, Importance.MEDIUM,
+            "Comma-separated list of roles and capabilities that define the permissions for each document")
+        .define(DOCUMENT_URI_PREFIX, Type.STRING, null, Importance.MEDIUM,
+            "Prefix to prepend to each URI; the URI itself is a UUID")
+        .define(DOCUMENT_URI_SUFFIX, Type.STRING, null, Importance.MEDIUM,
+            "Suffix to append to each URI; will determine the document type if ml.document.format is not set")
+        .define(DOCUMENT_TEMPORAL_COLLECTION, Type.STRING, null, Importance.MEDIUM,
+            "Name of a temporal collection for documents to be inserted into")
+        .define(DOCUMENT_COLLECTIONS_ADD_TOPIC, Type.BOOLEAN, null, Importance.MEDIUM,
+            "Set this to true so that the name of the topic that the connector reads from is added as a collection to each document inserted by the connector")
+        .define(DOCUMENT_MIMETYPE, Type.STRING, null, Importance.LOW,
+            "Specify a mime type for each document; typically ml.document.format will be used instead of this")
 
-        .define(ID_STRATEGY, Type.STRING, "", Importance.LOW, "The ID Strategy for URI.")
-        .define(ID_STRATEGY_PATH, Type.STRING, "", Importance.LOW, "The JSON path for ID Strategy");
+        .define(ID_STRATEGY, Type.STRING, null, Importance.LOW,
+            "Set the strategy for generating a unique URI for each document written to MarkLogic. Defaults to 'UUID'. Other choices are: 'JSONPATH', 'HASH', 'KAFKA_META_HASHED', and 'KAFKA_META_WITH_SLASH'.")
+        .define(ID_STRATEGY_PATH, Type.STRING, "", Importance.LOW,
+            "For use with 'JSONPATH' and 'HASH'; comma-separated list of paths for extracting values for the ID")
+
+        .define(DMSDK_BATCH_SIZE, Type.INT, 100, Importance.MEDIUM,
+            "Sets the number of documents to be written in a batch to MarkLogic. This may not have any impact depending on how the connector receives data from Kafka. The connector calls flushAsync on the DMSDK WriteBatcher after processing every collection of records. Thus, if the connector never receives at one time more than the value of this property, then the value of this property will have no impact.")
+        .define(DMSDK_THREAD_COUNT, Type.INT, 8, Importance.MEDIUM,
+            "Sets the number of threads used for parallel writes to MarkLogic. Similar to the batch size property above, this may never come into play depending on how many records the connector receives at once.")
+        .define(DMSDK_TRANSFORM, Type.STRING, null, Importance.MEDIUM,
+            "Name of a REST transform to use when writing documents")
+        .define(DMSDK_TRANSFORM_PARAMS, Type.STRING, null, Importance.MEDIUM,
+            "Delimited set of transform parameter names and values; example = param1,value1,param2,value2")
+        .define(DMSDK_TRANSFORM_PARAMS_DELIMITER, Type.STRING, ",", Importance.LOW,
+            "Delimiter for transform parameter names and values")
+
+        .define(LOGGING_RECORD_KEY, Type.BOOLEAN, null, Importance.LOW,
+            "Set to true to log at the info level the key of each record")
+        .define(LOGGING_RECORD_HEADERS, Type.BOOLEAN, null, Importance.LOW,
+            "Set to true to log at the info level the headers of each record")
+
+        .define(DATAHUB_FLOW_NAME, Type.STRING, null, Importance.LOW,
+            "Name of a Data Hub Framework flow to run after writing documents")
+        .define(DATAHUB_FLOW_STEPS, Type.STRING, null, Importance.LOW,
+            "Comma-delimited list of step numbers in a flow to run")
+        .define(DATAHUB_FLOW_LOG_RESPONSE, Type.BOOLEAN, null, Importance.LOW,
+            "Set to true to log at the info level the response data from running a flow");
 
     public MarkLogicSinkConfig(final Map<?, ?> originals) {
         super(CONFIG_DEF, originals, false);

--- a/src/main/java/com/marklogic/kafka/connect/sink/MarkLogicSinkTask.java
+++ b/src/main/java/com/marklogic/kafka/connect/sink/MarkLogicSinkTask.java
@@ -37,8 +37,12 @@ public class MarkLogicSinkTask extends SinkTask {
 
         Map<String, Object> parsedConfig = MarkLogicSinkConfig.CONFIG_DEF.parse(config);
 
-        logKeys = (Boolean) parsedConfig.get(MarkLogicSinkConfig.LOGGING_RECORD_KEY);
-        logHeaders = (Boolean) parsedConfig.get(MarkLogicSinkConfig.LOGGING_RECORD_HEADERS);
+        if (parsedConfig.get(MarkLogicSinkConfig.LOGGING_RECORD_KEY) != null) {
+            logKeys = (Boolean) parsedConfig.get(MarkLogicSinkConfig.LOGGING_RECORD_KEY);
+        }
+        if (parsedConfig.get(MarkLogicSinkConfig.LOGGING_RECORD_HEADERS) != null) {
+            logHeaders = (Boolean) parsedConfig.get(MarkLogicSinkConfig.LOGGING_RECORD_HEADERS);
+        }
 
         sinkRecordConverter = new DefaultSinkRecordConverter(parsedConfig);
 
@@ -118,7 +122,7 @@ public class MarkLogicSinkTask extends SinkTask {
         logger.info(logMessage);
 
         RunFlowWriteBatchListener listener = new RunFlowWriteBatchListener(flowName, steps, databaseClientConfig);
-        if (parsedConfig.containsKey(MarkLogicSinkConfig.DATAHUB_FLOW_LOG_RESPONSE)) {
+        if (parsedConfig.get(MarkLogicSinkConfig.DATAHUB_FLOW_LOG_RESPONSE) != null) {
             listener.setLogResponse((Boolean) parsedConfig.get(MarkLogicSinkConfig.DATAHUB_FLOW_LOG_RESPONSE));
         }
         return listener;

--- a/src/test/java/com/marklogic/kafka/connect/BuildDatabaseClientConfigTest.java
+++ b/src/test/java/com/marklogic/kafka/connect/BuildDatabaseClientConfigTest.java
@@ -98,10 +98,10 @@ public class BuildDatabaseClientConfigTest {
         String absolutePath = file.getAbsolutePath();
         config.put(MarkLogicSinkConfig.CONNECTION_SECURITY_CONTEXT_TYPE, "basic");
         config.put(MarkLogicSinkConfig.CONNECTION_SIMPLE_SSL, false);
-        config.put(MarkLogicSinkConfig.SSL, true);
+        config.put(MarkLogicSinkConfig.ENABLE_CUSTOM_SSL, true);
         config.put(MarkLogicSinkConfig.TLS_VERSION, "TLSv1.2");
         config.put(MarkLogicSinkConfig.SSL_HOST_VERIFIER, "STRICT");
-        config.put(MarkLogicSinkConfig.SSL_MUTUAL_AUTH, "true");
+        config.put(MarkLogicSinkConfig.SSL_MUTUAL_AUTH, true);
         config.put(MarkLogicSinkConfig.CONNECTION_CERT_FILE, absolutePath);
         config.put(MarkLogicSinkConfig.CONNECTION_CERT_PASSWORD, new Password("abc"));
 
@@ -118,10 +118,10 @@ public class BuildDatabaseClientConfigTest {
         String absolutePath = file.getAbsolutePath();
         config.put(MarkLogicSinkConfig.CONNECTION_SECURITY_CONTEXT_TYPE, "basic");
         config.put(MarkLogicSinkConfig.CONNECTION_SIMPLE_SSL, false);
-        config.put(MarkLogicSinkConfig.SSL, true);
+        config.put(MarkLogicSinkConfig.ENABLE_CUSTOM_SSL, true);
         config.put(MarkLogicSinkConfig.TLS_VERSION, "TLSv1.2");
         config.put(MarkLogicSinkConfig.SSL_HOST_VERIFIER, "SOMETHING");
-        config.put(MarkLogicSinkConfig.SSL_MUTUAL_AUTH, "true");
+        config.put(MarkLogicSinkConfig.SSL_MUTUAL_AUTH, true);
         config.put(MarkLogicSinkConfig.CONNECTION_CERT_FILE, absolutePath);
         config.put(MarkLogicSinkConfig.CONNECTION_CERT_PASSWORD, new Password("abc"));
 
@@ -139,10 +139,10 @@ public class BuildDatabaseClientConfigTest {
 
         config.put(MarkLogicSinkConfig.CONNECTION_SECURITY_CONTEXT_TYPE, "digest");
         config.put(MarkLogicSinkConfig.CONNECTION_SIMPLE_SSL, false);
-        config.put(MarkLogicSinkConfig.SSL, true);
+        config.put(MarkLogicSinkConfig.ENABLE_CUSTOM_SSL, true);
         config.put(MarkLogicSinkConfig.TLS_VERSION, "TLSv1.2");
         config.put(MarkLogicSinkConfig.SSL_HOST_VERIFIER, "STRICT");
-        config.put(MarkLogicSinkConfig.SSL_MUTUAL_AUTH, "false");
+        config.put(MarkLogicSinkConfig.SSL_MUTUAL_AUTH, false);
 
         DatabaseClientConfig clientConfig = builder.buildDatabaseClientConfig(config);
         assertEquals(SecurityContextType.DIGEST, clientConfig.getSecurityContextType());

--- a/src/test/resources/confluent/marklogic-purchases-connector.json
+++ b/src/test/resources/confluent/marklogic-purchases-connector.json
@@ -14,6 +14,7 @@
     "ml.document.format": "JSON",
     "ml.document.uriPrefix": "/purchase/",
     "ml.document.uriSuffix": ".json",
-    "ml.document.collections": "purchases,kafka-data"
+    "ml.document.collections": "purchases,kafka-data",
+    "ml.document.permissions": "rest-reader,read,rest-writer,update"
   }
 }


### PR DESCRIPTION
Resolves #57. 

- Updated docs for each config option so they're the same in all 3 places - README, marklogic-sink.properties, and MarkLogicSinkConfig
- Updated the CONTRIBUTING guide for testing with Apache Kafka
- Updated the README so it is focused on using the connectors as opposed to developing/testing them (more updates will happen to this before 1.7.0 is released)
