### PR TITLE
Can now include Kafka metadata on doc and log it when a failure occurs

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ connector.
 | ml.dmsdk.transform | | Name of a REST transform to use when writing documents |
 | ml.dmsdk.transformParams | | Delimited set of transform parameter names and values; example = param1,value1,param2,value2 |
 | ml.dmsdk.transformParamsDelimiter | , | Delimiter for transform parameter names and values |
+| ml.dmsdk.includeKafkaMetadata | false | Set to true so that Kafka record metadata is added to document metadata before it is written. If the document fails to be written, the Kafka record metadata will be logged as well. |
 | ml.log.record.key | false | Set to true to log at the info level the key of each record |
 | ml.log.record.headers | false | Set to true to log at the info level the headers of each record | 
 | ml.datahub.flow.name | | Name of a Data Hub Framework flow to run after writing documents |

--- a/config/marklogic-sink.properties
+++ b/config/marklogic-sink.properties
@@ -116,6 +116,10 @@ ml.dmsdk.threadCount=8
 # Delimiter for transform parameter names and values
 # ml.dmsdk.transformParamsDelimiter=,
 
+# Set to true so that Kafka record metadata is added to document metadata before it is written. If the document fails to
+# be written, the Kafka record metadata will be logged as well.
+# ml.dmsdk.includeKafkaMetadata=true
+
 # Set to true to log at the info level the key of each record
 # ml.log.record.key=true
 

--- a/src/main/java/com/marklogic/kafka/connect/ConfigUtil.java
+++ b/src/main/java/com/marklogic/kafka/connect/ConfigUtil.java
@@ -1,0 +1,21 @@
+package com.marklogic.kafka.connect;
+
+import java.util.Map;
+
+public abstract class ConfigUtil {
+
+    /**
+     * Convenience method for getting a boolean value from the parsed Kafka config, returning false if the given key is
+     * not found. This accounts for the fact that boolean options are expected to have "null" as a default value, which
+     * ensures in Confluent Platform that the default value is shown as "false". Oddly, if the default value is "false",
+     * then Confluent Platform seems to erroneously show the default value as "true".
+     *
+     * @param key
+     * @param parsedConfig
+     * @return
+     */
+    public final static boolean getBoolean(String key, Map<String, Object> parsedConfig) {
+        Boolean val = (Boolean) parsedConfig.get(key);
+        return val != null ? val : false;
+    }
+}

--- a/src/main/java/com/marklogic/kafka/connect/DefaultDatabaseClientConfigBuilder.java
+++ b/src/main/java/com/marklogic/kafka/connect/DefaultDatabaseClientConfigBuilder.java
@@ -47,12 +47,10 @@ public class DefaultDatabaseClientConfigBuilder extends LoggingObject implements
             clientConfig.setPassword(password.value());
         }
         clientConfig.setPort((Integer) parsedConfig.get(MarkLogicSinkConfig.CONNECTION_PORT));
-        Boolean customSsl = (Boolean) parsedConfig.get(MarkLogicSinkConfig.ENABLE_CUSTOM_SSL);
-        if (customSsl != null && customSsl) {
+        if (ConfigUtil.getBoolean(MarkLogicSinkConfig.ENABLE_CUSTOM_SSL, parsedConfig)) {
             configureCustomSslConnection(clientConfig, parsedConfig);
         }
-        Boolean simpleSsl = (Boolean) parsedConfig.get(MarkLogicSinkConfig.CONNECTION_SIMPLE_SSL);
-        if (simpleSsl != null && simpleSsl) {
+        if (ConfigUtil.getBoolean(MarkLogicSinkConfig.CONNECTION_SIMPLE_SSL, parsedConfig)) {
             configureSimpleSsl(clientConfig);
         }
         clientConfig.setUsername((String) parsedConfig.get(MarkLogicSinkConfig.CONNECTION_USERNAME));
@@ -90,12 +88,11 @@ public class DefaultDatabaseClientConfigBuilder extends LoggingObject implements
 
     private void configureCustomSslConnection(DatabaseClientConfig clientConfig, Map<String, Object> parsedConfig) {
         String tlsVersion = (String) parsedConfig.get(MarkLogicSinkConfig.TLS_VERSION);
-        Boolean sslMutualAuth = (Boolean) parsedConfig.get(MarkLogicSinkConfig.SSL_MUTUAL_AUTH);
         SSLContext sslContext = null;
         SecurityContextType securityContextType = clientConfig.getSecurityContextType();
 
         if (SecurityContextType.BASIC.equals(securityContextType) || SecurityContextType.DIGEST.equals(securityContextType)) {
-            if (sslMutualAuth != null && sslMutualAuth) {
+            if (ConfigUtil.getBoolean(MarkLogicSinkConfig.SSL_MUTUAL_AUTH, parsedConfig)) {
                 /*2 way ssl changes*/
                 KeyStore clientKeyStore = null;
                 try {

--- a/src/main/java/com/marklogic/kafka/connect/sink/MarkLogicSinkConfig.java
+++ b/src/main/java/com/marklogic/kafka/connect/sink/MarkLogicSinkConfig.java
@@ -33,6 +33,7 @@ public class MarkLogicSinkConfig extends AbstractConfig {
     public static final String DMSDK_TRANSFORM = "ml.dmsdk.transform";
     public static final String DMSDK_TRANSFORM_PARAMS = "ml.dmsdk.transformParams";
     public static final String DMSDK_TRANSFORM_PARAMS_DELIMITER = "ml.dmsdk.transformParamsDelimiter";
+    public static final String DMSDK_INCLUDE_KAFKA_METADATA = "ml.dmsdk.includeKafkaMetadata";
 
     public static final String DOCUMENT_COLLECTIONS_ADD_TOPIC = "ml.document.addTopicToCollections";
     public static final String DOCUMENT_COLLECTIONS = "ml.document.collections";
@@ -120,6 +121,8 @@ public class MarkLogicSinkConfig extends AbstractConfig {
             "Delimited set of transform parameter names and values; example = param1,value1,param2,value2")
         .define(DMSDK_TRANSFORM_PARAMS_DELIMITER, Type.STRING, ",", Importance.LOW,
             "Delimiter for transform parameter names and values")
+        .define(DMSDK_INCLUDE_KAFKA_METADATA, Type.BOOLEAN, null, Importance.LOW,
+            "Set to true so that Kafka record metadata is added to document metadata before it is written. If the document fails to be written, the Kafka record metadata will be logged as well.")
 
         .define(LOGGING_RECORD_KEY, Type.BOOLEAN, null, Importance.LOW,
             "Set to true to log at the info level the key of each record")

--- a/src/main/java/com/marklogic/kafka/connect/sink/WriteFailureHandler.java
+++ b/src/main/java/com/marklogic/kafka/connect/sink/WriteFailureHandler.java
@@ -1,0 +1,40 @@
+package com.marklogic.kafka.connect.sink;
+
+import com.marklogic.client.datamovement.WriteBatch;
+import com.marklogic.client.datamovement.WriteEvent;
+import com.marklogic.client.datamovement.WriteFailureListener;
+import com.marklogic.client.ext.helper.LoggingObject;
+import com.marklogic.client.io.DocumentMetadataHandle;
+import com.marklogic.client.io.marker.DocumentMetadataWriteHandle;
+
+/**
+ * Handles a failed write batch, which currently just consists of logging information about the failed batch.
+ */
+public class WriteFailureHandler extends LoggingObject implements WriteFailureListener {
+
+    private boolean includeKafkaMetadata;
+
+    public WriteFailureHandler(boolean includeKafkaMetadata) {
+        this.includeKafkaMetadata = includeKafkaMetadata;
+    }
+
+    @Override
+    public void processFailure(WriteBatch batch, Throwable throwable) {
+        logger.error("Batch failed; size: {}; cause: {}", batch.getItems().length, throwable.getMessage());
+        if (this.includeKafkaMetadata) {
+            logger.error("Logging Kafka record metadata for each failed document");
+            for (WriteEvent event : batch.getItems()) {
+                DocumentMetadataWriteHandle writeHandle = event.getMetadata();
+                if (writeHandle instanceof DocumentMetadataHandle) {
+                    DocumentMetadataHandle metadata = (DocumentMetadataHandle) writeHandle;
+                    DocumentMetadataHandle.DocumentMetadataValues values = metadata.getMetadataValues();
+                    if (values != null) {
+                        logger.error("URI: {}; key: {}; partition: {}; offset: {}; timestamp: {}; topic: {}",
+                            event.getTargetUri(), values.get("kafka-key"), values.get("kafka-partition"),
+                            values.get("kafka-offset"), values.get("kafka-timestamp"), values.get("kafka-topic"));
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/test/java/com/marklogic/kafka/connect/sink/AbstractIntegrationTest.java
+++ b/src/test/java/com/marklogic/kafka/connect/sink/AbstractIntegrationTest.java
@@ -61,7 +61,12 @@ public class AbstractIntegrationTest extends AbstractSpringMarkLogicTest {
     protected void putContent(MarkLogicSinkTask task, String content) {
         String topic = "topic-name-doesnt-matter";
         SinkRecord record = new SinkRecord(topic, 1, null, null, null, content, 0);
+        putSinkRecord(task, record);
+    }
+
+    protected void putSinkRecord(MarkLogicSinkTask task, SinkRecord record) {
         task.put(Stream.of(record).collect(Collectors.toList()));
         task.getWriteBatcher().flushAndWait();
     }
+
 }

--- a/src/test/java/com/marklogic/kafka/connect/sink/HandleWriteFailureTest.java
+++ b/src/test/java/com/marklogic/kafka/connect/sink/HandleWriteFailureTest.java
@@ -1,0 +1,95 @@
+package com.marklogic.kafka.connect.sink;
+
+import com.marklogic.client.datamovement.WriteBatch;
+import com.marklogic.client.io.DocumentMetadataHandle;
+import org.apache.kafka.common.record.TimestampType;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class HandleWriteFailureTest extends AbstractIntegrationTest {
+
+    /**
+     * This test is expected to log the URI of each failed document. We don't yet have a way to capture logging output
+     * to inspect it, so that part has to be done manually. The test does verify that the failed document contains
+     * Kafka metadata so that it can be logged.
+     */
+    @Test
+    void handleWriteFailure() {
+        final String TEST_COLLECTION = "handle-write-failure-test";
+
+        MarkLogicSinkTask task = startSinkTask(
+            MarkLogicSinkConfig.DOCUMENT_FORMAT, "json",
+            MarkLogicSinkConfig.DOCUMENT_COLLECTIONS, TEST_COLLECTION,
+            MarkLogicSinkConfig.DMSDK_INCLUDE_KAFKA_METADATA, "true"
+        );
+
+        // Register our own failure listener to inspect the failed batch
+        List<WriteBatch> failedBatches = new ArrayList<>();
+        task.getWriteBatcher().onBatchFailure(((batch, failure) -> {
+            failedBatches.add(batch);
+        }));
+
+        final String topic = "topic1";
+        final int partition = 1;
+        final String key = "key123";
+        final String value = "<not>json</not>";
+        final long offset = 123;
+        final Long timestamp = System.currentTimeMillis();
+
+        SinkRecord record = new SinkRecord(topic, partition, null, key, null, value, offset,
+            timestamp, TimestampType.CREATE_TIME);
+        putSinkRecord(task, record);
+
+        assertCollectionSize("The target collection should be empty since the content was not valid JSON",
+            TEST_COLLECTION, 0);
+
+        assertEquals(1, failedBatches.size());
+        DocumentMetadataHandle metadata = (DocumentMetadataHandle) failedBatches.get(0).getItems()[0].getMetadata();
+        DocumentMetadataHandle.DocumentMetadataValues values = metadata.getMetadataValues();
+        assertEquals(topic, values.get("kafka-topic"));
+        assertEquals(partition, Integer.parseInt(values.get("kafka-partition")));
+        assertEquals(key, values.get("kafka-key"));
+        assertEquals(offset, Long.parseLong(values.get("kafka-offset")));
+        assertEquals(timestamp, Long.parseLong(values.get("kafka-timestamp")));
+    }
+
+    /**
+     * This is just intended to ensure that null values in the Kafka metadata do not cause an error.
+     */
+    @Test
+    void handleWriteFailureWithMinimalKafkaMetadata() {
+        MarkLogicSinkTask task = startSinkTask(
+            MarkLogicSinkConfig.DOCUMENT_FORMAT, "json",
+            MarkLogicSinkConfig.DMSDK_INCLUDE_KAFKA_METADATA, "true"
+        );
+
+        List<WriteBatch> failedBatches = new ArrayList<>();
+        task.getWriteBatcher().onBatchFailure(((batch, failure) -> {
+            failedBatches.add(batch);
+        }));
+
+        final String topic = "topic1";
+        final int partition = 1;
+        final String value = "<not>json</not>";
+        final long offset = 123;
+        // Based on the constructor, it seems that partition/offset are guaranteed to exist, and we know topic will
+        // exist as well.
+        SinkRecord record = new SinkRecord(topic, partition, null, null, null, value, offset);
+        putSinkRecord(task, record);
+
+        assertEquals(1, failedBatches.size());
+        DocumentMetadataHandle metadata = (DocumentMetadataHandle) failedBatches.get(0).getItems()[0].getMetadata();
+        DocumentMetadataHandle.DocumentMetadataValues values = metadata.getMetadataValues();
+        assertEquals(topic, values.get("kafka-topic"));
+        assertEquals(partition, Integer.parseInt(values.get("kafka-partition")));
+        assertNull(values.get("kafka-key"));
+        assertEquals(offset, Long.parseLong(values.get("kafka-offset")));
+        assertNull(values.get("kafka-timestamp"));
+    }
+}

--- a/src/test/java/com/marklogic/kafka/connect/sink/WriteRecordWithKafkaMetadataTest.java
+++ b/src/test/java/com/marklogic/kafka/connect/sink/WriteRecordWithKafkaMetadataTest.java
@@ -1,0 +1,59 @@
+package com.marklogic.kafka.connect.sink;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.marklogic.client.io.DocumentMetadataHandle;
+import org.apache.kafka.common.record.TimestampType;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class WriteRecordWithKafkaMetadataTest extends AbstractIntegrationTest {
+
+    /**
+     * Verifies that when the option is set for including Kafka metadata, that metadata is present in the document
+     * metadata of each written document. The primary use case for this is to help with error logging by ensuring that
+     * the Kafka metadata is available to a DMSDK failure listener. Users may benefit too from the document metadata
+     * being available for inspection/query purposes.
+     */
+    @Test
+    void includeKafkaMetadata() {
+        final String TEST_COLLECTION = "include-kafka-metadata-test";
+
+        MarkLogicSinkTask task = startSinkTask(
+            MarkLogicSinkConfig.DOCUMENT_FORMAT, "json",
+            MarkLogicSinkConfig.DOCUMENT_COLLECTIONS, TEST_COLLECTION,
+            MarkLogicSinkConfig.DMSDK_INCLUDE_KAFKA_METADATA, "true",
+            MarkLogicSinkConfig.ID_STRATEGY, "JSONPATH",
+            MarkLogicSinkConfig.ID_STRATEGY_PATH, "/id",
+            MarkLogicSinkConfig.DOCUMENT_URI_PREFIX, "/TEST/",
+            MarkLogicSinkConfig.DOCUMENT_URI_SUFFIX, ".json"
+        );
+
+        ObjectNode content = new ObjectMapper().createObjectNode();
+        content.put("id", 100);
+        content.put("hello", "world");
+
+        final String topic = "topic1";
+        final int partition = 1;
+        final String key = "key123";
+        final long offset = 123;
+        final Long timestamp = System.currentTimeMillis();
+
+        SinkRecord record = new SinkRecord(topic, partition, null, key, null, content.toString(),
+            offset, timestamp, TimestampType.CREATE_TIME);
+        putSinkRecord(task, record);
+
+        assertCollectionSize(TEST_COLLECTION, 1);
+
+        DocumentMetadataHandle metadata = getDatabaseClient().newJSONDocumentManager()
+            .readMetadata("/TEST/100.json", new DocumentMetadataHandle());
+        DocumentMetadataHandle.DocumentMetadataValues values = metadata.getMetadataValues();
+        assertEquals(topic, values.get("kafka-topic"));
+        assertEquals(partition, Integer.parseInt(values.get("kafka-partition")));
+        assertEquals(key, values.get("kafka-key"));
+        assertEquals(offset, Long.parseLong(values.get("kafka-offset")));
+        assertEquals(timestamp, Long.parseLong(values.get("kafka-timestamp")));
+    }
+}


### PR DESCRIPTION
Resolves #31 . 

- Moved batch failure logging into a separate WriteFailureHandler class
- Added ConfigUtil.getBoolean to account for boolean options having null values, got rid of some boilerplate with this