### PR TITLE
Making task classes public again

### DIFF
--- a/src/main/java/com/marklogic/kafka/connect/sink/BulkDataServicesSinkTask.java
+++ b/src/main/java/com/marklogic/kafka/connect/sink/BulkDataServicesSinkTask.java
@@ -27,7 +27,7 @@ import java.util.Map;
  * to provide their own endpoint implementation, thus giving the user full control over how data is written to
  * MarkLogic.
  */
-class BulkDataServicesSinkTask extends AbstractSinkTask {
+public class BulkDataServicesSinkTask extends AbstractSinkTask {
 
     private DatabaseClient databaseClient;
     private InputCaller.BulkInputCaller<JsonNode> bulkInputCaller;

--- a/src/main/java/com/marklogic/kafka/connect/sink/WriteBatcherSinkTask.java
+++ b/src/main/java/com/marklogic/kafka/connect/sink/WriteBatcherSinkTask.java
@@ -23,7 +23,7 @@ import java.util.Map;
 /**
  * Uses MarkLogic's Data Movement SDK (DMSDK) to write data to MarkLogic.
  */
-class WriteBatcherSinkTask extends AbstractSinkTask {
+public class WriteBatcherSinkTask extends AbstractSinkTask {
 
     private DatabaseClient databaseClient;
     private DataMovementManager dataMovementManager;


### PR DESCRIPTION
These need to be public so that Kafka can instantiate them via reflection