### PR TITLE
DEVEXP-102: Integrate Kafka-Junit into the project for testing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,7 @@ dependencies {
 
   testImplementation "org.apache.kafka:connect-api:${kafkaVersion}"
   testImplementation "org.apache.kafka:connect-json:${kafkaVersion}"
+  testImplementation 'net.mguenther.kafka:kafka-junit:3.2.2'
 
   // Forcing logback to be used for test logging
   testImplementation "ch.qos.logback:logback-classic:1.2.11"

--- a/src/test/java/com/marklogic/kafka/connect/sink/ConvertSinkRecordTest.java
+++ b/src/test/java/com/marklogic/kafka/connect/sink/ConvertSinkRecordTest.java
@@ -28,12 +28,12 @@ public class ConvertSinkRecordTest {
     @Test
     void allPropertiesSet() {
         Map<String, Object> config = new HashMap<>();
-        config.put("ml.document.collections", "one,two");
-        config.put("ml.document.format", "json");
-        config.put("ml.document.mimeType", "application/json");
-        config.put("ml.document.permissions", "manage-user,read,manage-admin,update");
-        config.put("ml.document.uriPrefix", "/example/");
-        config.put("ml.document.uriSuffix", ".json");
+        config.put(MarkLogicSinkConfig.DOCUMENT_COLLECTIONS, "one,two");
+        config.put(MarkLogicSinkConfig.DOCUMENT_FORMAT, "json");
+        config.put(MarkLogicSinkConfig.DOCUMENT_MIMETYPE, "application/json");
+        config.put(MarkLogicSinkConfig.DOCUMENT_PERMISSIONS, "manage-user,read,manage-admin,update");
+        config.put(MarkLogicSinkConfig.DOCUMENT_URI_PREFIX, "/example/");
+        config.put(MarkLogicSinkConfig.DOCUMENT_URI_SUFFIX, ".json");
         converter = new DefaultSinkRecordConverter(config);
 
         DocumentWriteOperation op = converter.convert(newSinkRecord("test"));
@@ -75,7 +75,7 @@ public class ConvertSinkRecordTest {
     @Test
     void uriWithUUIDStrategy() {
         Map<String, Object> kafkaConfig = new HashMap<String, Object>();
-        kafkaConfig.put("ml.id.strategy", "UUID");
+        kafkaConfig.put(MarkLogicSinkConfig.ID_STRATEGY, "UUID");
         converter = new DefaultSinkRecordConverter(kafkaConfig);
 
         DocumentWriteOperation op = converter.convert(newSinkRecord("doesn't matter"));
@@ -106,7 +106,7 @@ public class ConvertSinkRecordTest {
     @Test
     void uriWithKafkaMetaData() {
         Map<String, Object> kafkaConfig = new HashMap<String, Object>();
-        kafkaConfig.put("ml.id.strategy", "KAFKA_META_WITH_SLASH");
+        kafkaConfig.put(MarkLogicSinkConfig.ID_STRATEGY, "KAFKA_META_WITH_SLASH");
         converter = new DefaultSinkRecordConverter(kafkaConfig);
 
         DocumentWriteOperation op = converter.convert(newSinkRecord("doesn't matter"));
@@ -122,8 +122,8 @@ public class ConvertSinkRecordTest {
     void uriWithJsonPath() throws IOException {
         JsonNode doc1 = new ObjectMapper().readTree("{\"f1\":\"100\"}");
         Map<String, Object> kafkaConfig = new HashMap<String, Object>();
-        kafkaConfig.put("ml.id.strategy", "JSONPATH");
-        kafkaConfig.put("ml.id.strategy.paths", "/f1");
+        kafkaConfig.put(MarkLogicSinkConfig.ID_STRATEGY, "JSONPATH");
+        kafkaConfig.put(MarkLogicSinkConfig.ID_STRATEGY_PATH, "/f1");
         converter = new DefaultSinkRecordConverter(kafkaConfig);
 
         DocumentWriteOperation op = converter.convert(newSinkRecord(doc1));
@@ -140,8 +140,8 @@ public class ConvertSinkRecordTest {
     void uriWithHashedJsonPaths() throws IOException {
         JsonNode doc1 = new ObjectMapper().readTree("{\"f1\":\"100\",\"f2\":\"200\"}");
         Map<String, Object> kafkaConfig = new HashMap<String, Object>();
-        kafkaConfig.put("ml.id.strategy", "HASH");
-        kafkaConfig.put("ml.id.strategy.paths", "/f1,/f2");
+        kafkaConfig.put(MarkLogicSinkConfig.ID_STRATEGY, "HASH");
+        kafkaConfig.put(MarkLogicSinkConfig.ID_STRATEGY_PATH, "/f1,/f2");
         converter = new DefaultSinkRecordConverter(kafkaConfig);
 
         DocumentWriteOperation op = converter.convert(newSinkRecord(doc1));
@@ -157,7 +157,7 @@ public class ConvertSinkRecordTest {
     @Test
     void uriWithHashedKafkaMeta() {
         Map<String, Object> kafkaConfig = new HashMap<String, Object>();
-        kafkaConfig.put("ml.id.strategy", "KAFKA_META_HASHED");
+        kafkaConfig.put(MarkLogicSinkConfig.ID_STRATEGY, "KAFKA_META_HASHED");
         converter = new DefaultSinkRecordConverter(kafkaConfig);
 
         DocumentWriteOperation op = converter.convert(newSinkRecord("doesn't matter"));

--- a/src/test/java/com/marklogic/kafka/connect/sink/MarkLogicSinkConnectorConfigBuilder.java
+++ b/src/test/java/com/marklogic/kafka/connect/sink/MarkLogicSinkConnectorConfigBuilder.java
@@ -1,0 +1,75 @@
+package com.marklogic.kafka.connect.sink;
+
+import org.apache.kafka.connect.runtime.ConnectorConfig;
+
+import java.util.Properties;
+import java.util.UUID;
+
+public class MarkLogicSinkConnectorConfigBuilder {
+
+    private String topic = String.format("topic-%s", UUID.randomUUID().toString());
+
+    private String key = String.format("key-%s", UUID.randomUUID().toString());
+
+    private final Properties connectorProps = new Properties();
+
+    public MarkLogicSinkConnectorConfigBuilder withTopic(final String topic) {
+        this.topic = topic;
+        return this;
+    }
+
+    public MarkLogicSinkConnectorConfigBuilder withKey(final String key) {
+        this.key = key;
+        return this;
+    }
+
+    public <T> MarkLogicSinkConnectorConfigBuilder with(final String propertyName, final T value) {
+        connectorProps.put(propertyName, value);
+        return this;
+    }
+
+    public <T> MarkLogicSinkConnectorConfigBuilder withAll(final Properties connectorProps) {
+        this.connectorProps.putAll(connectorProps);
+        return this;
+    }
+
+    private <T> void ifNonExisting(final String propertyName, final T value) {
+        if (connectorProps.get(propertyName) != null) return;
+        connectorProps.put(propertyName, value);
+    }
+
+    public Properties build() {
+
+        ifNonExisting(ConnectorConfig.NAME_CONFIG, "marklogic-sink");
+        ifNonExisting(ConnectorConfig.CONNECTOR_CLASS_CONFIG, "MarkLogicSinkConnector");
+        ifNonExisting(ConnectorConfig.TASKS_MAX_CONFIG, "1");
+        ifNonExisting("topics", topic);
+        ifNonExisting("key", key);
+
+        ifNonExisting(MarkLogicSinkConfig.CONNECTION_HOST, "localhost");
+        ifNonExisting(MarkLogicSinkConfig.CONNECTION_PORT, "8000");
+        ifNonExisting(MarkLogicSinkConfig.CONNECTION_SECURITY_CONTEXT_TYPE, "DIGEST");
+        ifNonExisting(MarkLogicSinkConfig.CONNECTION_USERNAME, "admin");
+        ifNonExisting(MarkLogicSinkConfig.CONNECTION_PASSWORD, "admin");
+        ifNonExisting(MarkLogicSinkConfig.DOCUMENT_FORMAT, "JSON");
+        ifNonExisting(MarkLogicSinkConfig.DOCUMENT_COLLECTIONS, "kafka-data");
+        ifNonExisting(MarkLogicSinkConfig.DOCUMENT_PERMISSIONS, "rest-reader,read,rest-writer,update");
+        ifNonExisting(MarkLogicSinkConfig.DOCUMENT_URI_PREFIX, "/kafka-data/");
+        ifNonExisting(MarkLogicSinkConfig.DOCUMENT_URI_SUFFIX, ".json");
+        ifNonExisting(MarkLogicSinkConfig.DMSDK_BATCH_SIZE, "100");
+        ifNonExisting(MarkLogicSinkConfig.DMSDK_THREAD_COUNT, "8");
+        ifNonExisting("key.converter", "org.apache.kafka.connect.storage.StringConverter");
+        ifNonExisting("value.converter", "org.apache.kafka.connect.storage.StringConverter");
+        ifNonExisting("errors.log.enable", true);
+
+        final Properties copyOfConnectorProps = new Properties();
+        copyOfConnectorProps.putAll(connectorProps);
+
+        return copyOfConnectorProps;
+    }
+
+    public static MarkLogicSinkConnectorConfigBuilder create() {
+        return new MarkLogicSinkConnectorConfigBuilder();
+    }
+}
+

--- a/src/test/java/com/marklogic/kafka/connect/sink/WriteFromKafkaTest.java
+++ b/src/test/java/com/marklogic/kafka/connect/sink/WriteFromKafkaTest.java
@@ -1,0 +1,84 @@
+package com.marklogic.kafka.connect.sink;
+
+import com.marklogic.client.io.SearchHandle;
+import com.marklogic.client.query.StructuredQueryBuilder;
+import com.marklogic.client.query.StructuredQueryDefinition;
+import kafka.server.KafkaConfig$;
+import net.mguenther.kafka.junit.*;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.*;
+import static net.mguenther.kafka.junit.EmbeddedConnectConfig.kafkaConnect;
+import static net.mguenther.kafka.junit.EmbeddedKafkaCluster.provisionWith;
+import static net.mguenther.kafka.junit.EmbeddedKafkaClusterConfig.newClusterConfig;
+
+public class WriteFromKafkaTest extends AbstractIntegrationTest {
+
+    private final String ML_COLLECTION = "kafka-data";
+    private final String TOPIC = "test-topic";
+    private final String KEY = String.format("key-%s", UUID.randomUUID());
+
+    private EmbeddedKafkaCluster kafka;
+
+    @BeforeEach
+    void setupKafka() {
+        provisionKafkaWithConnectAndMarkLogicConnector();
+        kafka.start();
+    }
+
+    @AfterEach
+    void tearDownKafka() {
+        kafka.stop();
+    }
+
+    @Test
+    void shouldWaitForKeyedRecordsToBePublished() throws InterruptedException {
+        Integer NUM_RECORDS = 2;
+        sendSomeJsonMessages(NUM_RECORDS);
+        retryIfNotSuccessful(() -> assertMarkLogicDocumentsExistInCollection(ML_COLLECTION, NUM_RECORDS,
+            format("Expected to find %d records in the ML database", NUM_RECORDS)));
+    }
+
+    private void provisionKafkaWithConnectAndMarkLogicConnector() {
+        kafka = provisionWith(
+            newClusterConfig()
+                .configure(
+                    kafkaConnect()
+                        .deployConnector(connectorConfig(TOPIC, KEY))
+                        .with(KafkaConfig$.MODULE$.NumPartitionsProp(), "5")
+                )
+        );
+    }
+
+    private Properties connectorConfig(final String topic, final String key) {
+        return MarkLogicSinkConnectorConfigBuilder.create()
+            .withTopic(topic)
+            .withKey(key)
+            .with(MarkLogicSinkConfig.CONNECTION_HOST, testConfig.getHost())
+            .with(MarkLogicSinkConfig.CONNECTION_PORT, testConfig.getRestPort())
+            .with(MarkLogicSinkConfig.CONNECTION_USERNAME, testConfig.getUsername())
+            .with(MarkLogicSinkConfig.CONNECTION_PASSWORD, testConfig.getPassword())
+            .with(MarkLogicSinkConfig.DOCUMENT_COLLECTIONS, ML_COLLECTION)
+            .with(MarkLogicSinkConfig.DMSDK_BATCH_SIZE, 1)
+            .build();
+    }
+
+    private void sendSomeJsonMessages(Integer numberOfRecords) throws InterruptedException {
+        List<KeyValue<String, String>> records = new ArrayList<>();
+        for (int i = 0; i < numberOfRecords; i++) {
+            records.add(new KeyValue<>("aggregate", "{\"A\": \"" + i + "\"}"));
+        }
+        kafka.send(SendKeyValues.to(TOPIC, records));
+    }
+
+    private void assertMarkLogicDocumentsExistInCollection(String collection, Integer numRecords, String message) {
+        StructuredQueryBuilder qb = new StructuredQueryBuilder();
+        StructuredQueryDefinition queryDefinition = qb.collection(collection);
+        SearchHandle results = getDatabaseClient().newQueryManager().search(queryDefinition, new SearchHandle());
+        assertEquals(numRecords.longValue(), results.getTotalResults(), message);
+    }
+}

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -8,11 +8,27 @@
     </encoder>
   </appender>
 
-  <root level="INFO">
+  <root level="WARN">
     <appender-ref ref="STDOUT"/>
   </root>
 
   <logger name="com.marklogic" level="INFO" additivity="false">
+    <appender-ref ref="STDOUT"/>
+  </logger>
+
+  <logger name="org.reflections" level="ERROR" additivity="false">
+    <appender-ref ref="STDOUT"/>
+  </logger>
+
+  <logger name="org.apache.kafka" level="ERROR" additivity="false">
+    <appender-ref ref="STDOUT"/>
+  </logger>
+
+  <logger name="kafka.server" level="ERROR" additivity="false">
+    <appender-ref ref="STDOUT"/>
+  </logger>
+
+  <logger name="org.apache.zookeeper" level="ERROR" additivity="false">
     <appender-ref ref="STDOUT"/>
   </logger>
 


### PR DESCRIPTION
Integrate Kafka-Junit into the project by creating a simple test of the existing ML connector functionality