### PR TITLE
Tests now run as a minimal user

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
   id "com.github.jk1.dependency-license-report" version "1.3"
 
   // Only used for testing
-  id 'com.marklogic.ml-gradle' version '4.3.5'
+  id 'com.marklogic.ml-gradle' version '4.3.7'
 }
 
 java {

--- a/src/main/java/com/marklogic/kafka/connect/source/MarkLogicSourceConfig.java
+++ b/src/main/java/com/marklogic/kafka/connect/source/MarkLogicSourceConfig.java
@@ -34,7 +34,7 @@ public class MarkLogicSourceConfig extends MarkLogicConfig {
                 "Controls whether to get an immutable view of the result set")
             .define(TOPIC, Type.STRING, ConfigDef.NO_DEFAULT_VALUE, ConfigDef.CompositeValidator.of(new ConfigDef.NonNullValidator(), new ConfigDef.NonEmptyString()), Importance.HIGH,
                 "Required; the name of the target topic to publish records to")
-            .define(WAIT_TIME, Type.LONG, 5000, ConfigDef.Range.atLeast(1), Importance.MEDIUM,
+            .define(WAIT_TIME, Type.LONG, 5000, ConfigDef.Range.atLeast(0), Importance.MEDIUM,
                 "Sets the minimum time (in ms) between polling operations")
 
             .define(DMSDK_BATCH_SIZE, Type.INT, 100, ConfigDef.Range.atLeast(1), Importance.MEDIUM,

--- a/src/test/java/com/marklogic/kafka/connect/AbstractIntegrationTest.java
+++ b/src/test/java/com/marklogic/kafka/connect/AbstractIntegrationTest.java
@@ -17,8 +17,11 @@ public class AbstractIntegrationTest extends AbstractSpringMarkLogicTest {
         config.put(MarkLogicSinkConfig.CONNECTION_HOST, testConfig.getHost());
         config.put(MarkLogicSinkConfig.CONNECTION_PORT, testConfig.getRestPort() + "");
         config.put(MarkLogicSinkConfig.CONNECTION_SECURITY_CONTEXT_TYPE, "DIGEST");
-        config.put(MarkLogicSinkConfig.CONNECTION_USERNAME, testConfig.getUsername());
-        config.put(MarkLogicSinkConfig.CONNECTION_PASSWORD, testConfig.getPassword());
+
+        // Default to a "bare minimum" user, which is defined in src/test/ml-config
+        config.put(MarkLogicSinkConfig.CONNECTION_USERNAME, "kafka-test-user");
+        config.put(MarkLogicSinkConfig.CONNECTION_PASSWORD, "kafkatest");
+
         return config;
     }
 }

--- a/src/test/java/com/marklogic/kafka/connect/source/AbstractIntegrationSourceTest.java
+++ b/src/test/java/com/marklogic/kafka/connect/source/AbstractIntegrationSourceTest.java
@@ -28,6 +28,7 @@ public class AbstractIntegrationSourceTest extends AbstractIntegrationTest {
      */
     protected RowBatcherSourceTask startSourceTask(String... configParamNamesAndValues) {
         Map<String, String> config = newMarkLogicConfig(testConfig);
+        config.put(MarkLogicSourceConfig.WAIT_TIME, "0");
         for (int i = 0; i < configParamNamesAndValues.length; i += 2) {
             config.put(configParamNamesAndValues[i], configParamNamesAndValues[i + 1]);
         }

--- a/src/test/java/com/marklogic/kafka/connect/source/MarkLogicSourceConfigTest.java
+++ b/src/test/java/com/marklogic/kafka/connect/source/MarkLogicSourceConfigTest.java
@@ -57,9 +57,9 @@ class MarkLogicSourceConfigTest extends AbstractIntegrationSourceTest {
         Assertions.assertThrows(ConfigException.class, () -> configDef.parse(config));
         config.put(MarkLogicSourceConfig.WAIT_TIME, "asdf");
         Assertions.assertThrows(ConfigException.class, () -> configDef.parse(config));
-        config.put(MarkLogicSourceConfig.WAIT_TIME, 0);
+        config.put(MarkLogicSourceConfig.WAIT_TIME, -1);
         Assertions.assertThrows(ConfigException.class, () -> configDef.parse(config));
-        config.put(MarkLogicSourceConfig.WAIT_TIME, 1000);
+        config.put(MarkLogicSourceConfig.WAIT_TIME, 0);
         configDef.parse(config);
     }
 

--- a/src/test/java/com/marklogic/kafka/connect/source/ReadRowsViaOpticDslKafkaTest.java
+++ b/src/test/java/com/marklogic/kafka/connect/source/ReadRowsViaOpticDslKafkaTest.java
@@ -69,6 +69,7 @@ public class ReadRowsViaOpticDslKafkaTest extends AbstractIntegrationSourceTest 
         return MarkLogicSourceConnectorConfigBuilder.create()
             .withTopic(topic)
             .withDsl(opticDsl)
+            .with(MarkLogicSourceConfig.WAIT_TIME, 0)
             .with(MarkLogicSourceConfig.CONNECTION_HOST, testConfig.getHost())
             .with(MarkLogicSourceConfig.CONNECTION_PORT, testConfig.getRestPort())
             .with(MarkLogicSourceConfig.CONNECTION_USERNAME, testConfig.getUsername())

--- a/src/test/java/com/marklogic/kafka/connect/source/ReadRowsViaOpticDslTest.java
+++ b/src/test/java/com/marklogic/kafka/connect/source/ReadRowsViaOpticDslTest.java
@@ -3,6 +3,7 @@ package com.marklogic.kafka.connect.source;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.marklogic.client.datamovement.RowBatcher;
 import com.marklogic.client.document.XMLDocumentManager;
+import com.marklogic.client.io.DocumentMetadataHandle;
 import com.marklogic.client.io.FileHandle;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.junit.jupiter.api.Assertions;
@@ -106,6 +107,8 @@ class ReadRowsViaOpticDslTest extends AbstractIntegrationSourceTest {
 
     private void loadMarkLogicTestData() {
         XMLDocumentManager docMgr = getDatabaseClient().newXMLDocumentManager();
-        docMgr.write("citations.xml", new FileHandle(new File("src/test/resources/citations.xml")));
+        docMgr.write("citations.xml",
+            new DocumentMetadataHandle().withPermission("kafka-test-minimal-user", DocumentMetadataHandle.Capability.READ, DocumentMetadataHandle.Capability.UPDATE),
+            new FileHandle(new File("src/test/resources/citations.xml")));
     }
 }


### PR DESCRIPTION
Adjusted minimum wait time to be zero, and "read" tests now use that so they can run as fast as possible