### PR TITLE
DEVEXP-126: Initial readme/contributing for source connector

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,7 +91,7 @@ In the Control Center GUI, you can verify the Datagen connector instance:
 
 1. Click on "Connect" in the left sidebar
 2. Click on the "connect-default" cluster
-3. Click on the "datagen-purchases" connector
+3. Click on the "datagen-purchases-source" connector
 
 Additionally, you can examine the data sent by the Datagen connector to the `purchases` topic:
 
@@ -99,25 +99,24 @@ Additionally, you can examine the data sent by the Datagen connector to the `pur
 2. Click on the "purchases" topic
 3. Click on "Messages" to see the JSON documents being sent by the connector
 
-## Load a MarkLogic Kafka connector instance
+## Load a MarkLogic Kafka sink connector instance
 
 Next, load an instance of the MarkLogic Kafka connector that will read data from the `purchases` topic and write
-it to MarkLogic. The `src/test/resources/confluent/marklogic-purchases-connector.json` file defines the connection
-properties for MarkLogic, and it defaults to writing to the `Documents` database via port 8000. You can adjust this file
-to suit your testing needs.
+it to MarkLogic. The `src/test/resources/confluent/marklogic-purchases-sink.json` file defines the connection
+properties for MarkLogic. You can adjust this file to suit your testing needs.
 
-    ./gradlew loadMarkLogicPurchasesConnector
+    ./gradlew loadMarkLogicPurchasesSinkConnector
 
 In the Control Center GUI, you can verify the MarkLogic Kafka connector instance:
 
 1. Click on "Connect" in the left sidebar
 2. Click on the "connect-default" cluster
-3. Click on the "marklogic-purchases" connector
+3. Click on the "marklogic-purchases-sink" connector
 
 You can then verify that data is being written to MarkLogic by using MarkLogic's qconsole application to inspect the
-contents of the `Documents` database.
+contents of the `kafka-test-content` database.
 
-You can also manually configure an instance of the MarkLogic Kafka connector as well:
+You can also manually configure an instance of the sink connector:
 
 1. Click on "Connect" in the left sidebar
 2. Click on the "connect-default" cluster
@@ -132,6 +131,41 @@ You can also manually configure an instance of the MarkLogic Kafka connector as 
 
 In the list of connectors in Control Center, the connector will initially have a status of "Failed" while it starts up.
 After it starts successfully, it will have a status of "Running". 
+
+## Load a MarkLogic Kafka source connector instance
+
+You can also load an instance of the MarkLogic Kafka source connector that will read rows from the `demo/purchases` 
+view that is created via the TDE template at `src/test/ml-schemas/tde/purchases.json`. 
+The `src/test/reosurces/confluent/marklogic-purchases-source.json` file defines the connection properties for MarkLogic.
+You can adjust this file to suit your testing needs.
+
+    ./gradlew loadMarkLogicPurchasesSourceConnector
+
+In the Control Center GUI, you can verify the MarkLogic Kafka connector instance:
+
+1. Click on "Connect" in the left sidebar
+2. Click on the "connect-default" cluster
+3. Click on the "marklogic-purchases-source" connector
+
+You can verify that data is being read from the `demo/purchases` view and sent to the `marklogic-purchases` topic 
+by clicking on "Topics" in Confluent Platform and then selecting "marklogic-purchases".
+
+You can also manually configure an instance of the source connector:
+
+1. Click on "Connect" in the left sidebar
+2. Click on the "connect-default" cluster
+3. Click on "Add connector"
+4. Click on "MarkLogicSourceConnector"
+5. For "Value converter class", enter `org.apache.kafka.connect.json.JsonConverter`
+6. Under "General", enter values for the required MarkLogic connection fields
+7. Enter an Optic DSL query for `ml.source.optic.dsl` and a Kafka topic name for `ml.source.topic`
+8. Add values for any optional fields that you wish to populate
+9. At the bottom of the page, click "Next"
+10. Click "Launch"
+
+In the list of connectors in Control Center, the connector will initially have a status of "Failed" while it starts up.
+After it starts successfully, it will have a status of "Running".
+
 
 ## Debugging the MarkLogic Kafka connector
 

--- a/build.gradle
+++ b/build.gradle
@@ -189,6 +189,8 @@ task copyConnectorToConfluent(type: Copy, group: confluentTestingGroup, dependsO
 task destroyLocalConfluent(type: Exec, group: confluentTestingGroup) {
   description = "Destroy the local Confluent Platform instance"
   commandLine "confluent", "local", "destroy"
+  // Main reason this will fail is because Confluent is not running, which shouldn't cause a failure
+  ignoreExitValue = true
 }
 
 // See https://docs.confluent.io/confluent-cli/current/command-reference/local/services/confluent_local_services_start.html
@@ -200,20 +202,28 @@ task startLocalConfluent(type: Exec, group: confluentTestingGroup) {
 task loadDatagenPurchasesConnector(type: Exec, group: confluentTestingGroup) {
   description = "Load an instance of the Datagen connector into Confluent Platform for sending JSON documents to " +
     "the 'purchases' topic"
-  commandLine "confluent", "local", "services", "connect", "connector", "load", "datagen-purchases", "-c",
-    "src/test/resources/confluent/datagen-purchases-connector.json"
+  commandLine "confluent", "local", "services", "connect", "connector", "load", "datagen-purchases-source", "-c",
+    "src/test/resources/confluent/datagen-purchases-source.json"
 }
 
-task loadMarkLogicPurchasesConnector(type: Exec, group: confluentTestingGroup) {
+task loadMarkLogicPurchasesSinkConnector(type: Exec, group: confluentTestingGroup) {
   description = "Load an instance of the MarkLogic Kafka connector into Confluent Platform for writing data to " +
     "MarkLogic from the 'purchases' topic"
-  commandLine "confluent", "local", "services", "connect", "connector", "load", "marklogic-purchases", "-c",
-    "src/test/resources/confluent/marklogic-purchases-connector.json"
+  commandLine "confluent", "local", "services", "connect", "connector", "load", "marklogic-purchases-sink", "-c",
+    "src/test/resources/confluent/marklogic-purchases-sink.json"
+}
+
+task loadMarkLogicPurchasesSourceConnector(type: Exec, group: confluentTestingGroup) {
+  description = "Load an instance of the MarkLogic Kafka connector into Confluent Platform for reading rows from " +
+    "the demo/purchases view"
+  commandLine "confluent", "local", "services", "connect", "connector", "load", "marklogic-purchases-source", "-c",
+    "src/test/resources/confluent/marklogic-purchases-source.json"
 }
 
 task setupLocalConfluent(group: confluentTestingGroup) {
   description = "Start a local Confluent Platform instance and load the Datagen and MarkLogic connectors"
 }
-setupLocalConfluent.dependsOn startLocalConfluent, loadDatagenPurchasesConnector, loadMarkLogicPurchasesConnector
+setupLocalConfluent.dependsOn startLocalConfluent, loadDatagenPurchasesConnector, loadMarkLogicPurchasesSinkConnector, loadMarkLogicPurchasesSourceConnector
 loadDatagenPurchasesConnector.mustRunAfter startLocalConfluent
-loadMarkLogicPurchasesConnector.mustRunAfter startLocalConfluent
+loadMarkLogicPurchasesSinkConnector.mustRunAfter startLocalConfluent
+loadMarkLogicPurchasesSourceConnector.mustRunAfter startLocalConfluent

--- a/src/main/java/com/marklogic/kafka/connect/sink/MarkLogicSinkConfig.java
+++ b/src/main/java/com/marklogic/kafka/connect/sink/MarkLogicSinkConfig.java
@@ -44,7 +44,9 @@ public class MarkLogicSinkConfig extends MarkLogicConfig {
     public static final ConfigDef CONFIG_DEF = getConfigDef();
 
     private static ConfigDef getConfigDef() {
-        ConfigDef configDef = new ConfigDef()
+        ConfigDef configDef = new ConfigDef();
+        MarkLogicConfig.addDefinitions(configDef);
+        return configDef
             .define(BULK_DS_ENDPOINT_URI, Type.STRING, null, Importance.LOW,
                 "Defines the URI of a Bulk Data Services endpoint for writing data. " +
                     "See the user guide for more information on using Bulk Data Services instead of DMSDK for writing data to MarkLogic.")
@@ -98,8 +100,6 @@ public class MarkLogicSinkConfig extends MarkLogicConfig {
                 "Comma-delimited list of step numbers in a flow to run")
             .define(DATAHUB_FLOW_LOG_RESPONSE, Type.BOOLEAN, null, Importance.LOW,
                 "Set to true to log at the info level the response data from running a flow");
-        MarkLogicConfig.addDefinitions(configDef);
-        return configDef;
     }
 
     public MarkLogicSinkConfig(final Map<?, ?> originals) {

--- a/src/main/java/com/marklogic/kafka/connect/source/MarkLogicSourceConfig.java
+++ b/src/main/java/com/marklogic/kafka/connect/source/MarkLogicSourceConfig.java
@@ -25,24 +25,26 @@ public class MarkLogicSourceConfig extends MarkLogicConfig {
     public static final ConfigDef CONFIG_DEF = getConfigDef();
 
     private static ConfigDef getConfigDef() {
-        ConfigDef configDef = new ConfigDef()
-            .define(DSL_PLAN, Type.STRING, ConfigDef.NO_DEFAULT_VALUE, ConfigDef.CompositeValidator.of(new ConfigDef.NonNullValidator(), new ConfigDef.NonEmptyString()), Importance.HIGH,
-                "Required; a MarkLogic Optic DSL plan for querying the database")
-            .define(JOB_NAME, Type.STRING, "", new ConfigDef.NonNullValidator(), Importance.MEDIUM,
-                "Specifies the name for the query job executed by the connector task")
-            .define(CONSISTENT_SNAPSHOT, Type.BOOLEAN, true, new BooleanValidator(), Importance.MEDIUM,
-                "Controls whether to get an immutable view of the result set")
-            .define(TOPIC, Type.STRING, ConfigDef.NO_DEFAULT_VALUE, ConfigDef.CompositeValidator.of(new ConfigDef.NonNullValidator(), new ConfigDef.NonEmptyString()), Importance.HIGH,
-                "Required; the name of the target topic to publish records to")
-            .define(WAIT_TIME, Type.LONG, 5000, ConfigDef.Range.atLeast(0), Importance.MEDIUM,
-                "Sets the minimum time (in ms) between polling operations")
-
-            .define(DMSDK_BATCH_SIZE, Type.INT, 100, ConfigDef.Range.atLeast(1), Importance.MEDIUM,
-                "Sets the number of documents to be read in a batch from MarkLogic")
-            .define(DMSDK_THREAD_COUNT, Type.INT, 8, ConfigDef.Range.atLeast(1), Importance.MEDIUM,
-                "Sets the number of threads used for parallel reads from MarkLogic");
+        ConfigDef configDef = new ConfigDef();
         MarkLogicConfig.addDefinitions(configDef);
-        return configDef;
+        return configDef
+            .define(DSL_PLAN, Type.STRING, ConfigDef.NO_DEFAULT_VALUE, ConfigDef.CompositeValidator.of(new ConfigDef.NonNullValidator(), new ConfigDef.NonEmptyString()), Importance.HIGH,
+                "Required; the Optic DSL query to execute")
+            .define(TOPIC, Type.STRING, ConfigDef.NO_DEFAULT_VALUE, ConfigDef.CompositeValidator.of(new ConfigDef.NonNullValidator(), new ConfigDef.NonEmptyString()), Importance.HIGH,
+                "Required; the name of a Kafka topic to send records to")
+            .define(WAIT_TIME, Type.LONG, 5000, ConfigDef.Range.atLeast(0), Importance.MEDIUM,
+                "TBD, we're changing this soon")
+            .define(JOB_NAME, Type.STRING, "", new ConfigDef.NonNullValidator(), Importance.MEDIUM,
+                "name for the job run by the connector; the main use case for this is to " +
+                    "enhance logging by having a known job name appear in the logs")
+            .define(CONSISTENT_SNAPSHOT, Type.BOOLEAN, true, new BooleanValidator(), Importance.MEDIUM,
+                "enables retrieval of rows that were present in the view at the time that the " +
+                    "first batch is retrieved, ignoring subsequent changes to the view; defaults to true; setting this to false will " +
+                    "result in matching rows inserted or updated after the retrieval of the first batch being included as well")
+            .define(DMSDK_BATCH_SIZE, Type.INT, 100, ConfigDef.Range.atLeast(1), Importance.MEDIUM,
+                "sets the number of rows to be read in a batch from MarkLogic; can adjust this to tune performance")
+            .define(DMSDK_THREAD_COUNT, Type.INT, 8, ConfigDef.Range.atLeast(1), Importance.MEDIUM,
+                "sets the number of threads to use for reading batches of rows from MarkLogic; can adjust this to tune performance");
     }
 
     private MarkLogicSourceConfig(final Map<?, ?> originals) {

--- a/src/main/java/com/marklogic/kafka/connect/source/RowBatcherSourceTask.java
+++ b/src/main/java/com/marklogic/kafka/connect/source/RowBatcherSourceTask.java
@@ -153,12 +153,14 @@ public class RowBatcherSourceTask extends SourceTask {
         logger.debug("JsonNode: \n" + rows.toPrettyString());
 
         String topic = (String) parsedConfig.get(MarkLogicSourceConfig.TOPIC);
-        Integer rowNumber = 1;
         for (JsonNode row : rows) {
 // We may need to add a switch to include a key in the record depending on how the target topic is configured.
 // If the topic's cleanup policy is set to "compact", then a key is required to be included in the SourceRecord.
 //            String key = event.getJobBatchNumber() + "-" + rowNumber;
-            SourceRecord newRecord = new SourceRecord(null, null, topic, null, row);
+
+            // Calling toString on the JsonNode, as when this is run in Confluent Platform, we get the following
+            // error: org.apache.kafka.connect.errors.DataException: Java class com.fasterxml.jackson.databind.node.ObjectNode does not have corresponding schema type.
+            SourceRecord newRecord = new SourceRecord(null, null, topic, null, row.toString());
             newSourceRecords.add(newRecord);
         }
     }

--- a/src/test/java/com/marklogic/kafka/connect/source/ReadRowsViaOpticDslTest.java
+++ b/src/test/java/com/marklogic/kafka/connect/source/ReadRowsViaOpticDslTest.java
@@ -96,8 +96,10 @@ class ReadRowsViaOpticDslTest extends AbstractIntegrationSourceTest {
         AtomicReference<Boolean> foundExpectedValue = new AtomicReference<>(false);
         newSourceRecords.forEach(sourceRecord -> {
             Assertions.assertEquals(topic, sourceRecord.topic());
+            assertTrue(sourceRecord.value() instanceof String, "Until we figure out how to return a JsonNode and make " +
+                "Confluent Platform happy, we expect the JsonNode to be toString'ed; type: " + sourceRecord.value().getClass());
             System.out.println(sourceRecord.value());
-            if (expectedValue.equals(sourceRecord.value().toString())) {
+            if (expectedValue.equals(sourceRecord.value())) {
                 foundExpectedValue.set(true);
             }
         });

--- a/src/test/ml-schemas/tde/purchases.json
+++ b/src/test/ml-schemas/tde/purchases.json
@@ -1,0 +1,37 @@
+{
+  "template": {
+    "description": "Projects rows from the purchase documents expected to be written by the datagen connector",
+    "context": "/",
+    "collections": [
+      "purchases"
+    ],
+    "rows": [
+      {
+        "schemaName": "demo",
+        "viewName": "purchases",
+        "columns": [
+          {
+            "name": "id",
+            "scalarType": "long",
+            "val": "id"
+          },
+          {
+            "name": "item_type",
+            "scalarType": "string",
+            "val": "item_type"
+          },
+          {
+            "name": "quantity",
+            "scalarType": "int",
+            "val": "quantity"
+          },
+          {
+            "name": "price_per_unit",
+            "scalarType": "float",
+            "val": "price_per_unit"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/test/resources/confluent/datagen-purchases-source.json
+++ b/src/test/resources/confluent/datagen-purchases-source.json
@@ -1,5 +1,5 @@
 {
-  "name": "datagen-purchases",
+  "name": "datagen-purchases-source",
   "config": {
     "connector.class": "io.confluent.kafka.connect.datagen.DatagenConnector",
     "kafka.topic": "purchases",

--- a/src/test/resources/confluent/marklogic-purchases-sink.json
+++ b/src/test/resources/confluent/marklogic-purchases-sink.json
@@ -1,5 +1,5 @@
 {
-  "name": "marklogic-purchases",
+  "name": "marklogic-purchases-sink",
   "config": {
     "topics": "purchases",
     "connector.class": "com.marklogic.kafka.connect.sink.MarkLogicSinkConnector",
@@ -7,14 +7,14 @@
     "value.converter": "org.apache.kafka.connect.storage.StringConverter",
     "tasks.max": "1",
     "ml.connection.host": "localhost",
-    "ml.connection.port": 8000,
-    "ml.connection.username": "admin",
-    "ml.connection.password": "admin",
+    "ml.connection.port": 8018,
+    "ml.connection.username": "kafka-test-user",
+    "ml.connection.password": "kafkatest",
     "ml.connection.securityContextType": "DIGEST",
     "ml.document.format": "JSON",
     "ml.document.uriPrefix": "/purchase/",
     "ml.document.uriSuffix": ".json",
     "ml.document.collections": "purchases,kafka-data",
-    "ml.document.permissions": "rest-reader,read,rest-writer,update"
+    "ml.document.permissions": "kafka-test-minimal-user,read,kafka-test-minimal-user,update"
   }
 }

--- a/src/test/resources/confluent/marklogic-purchases-source.json
+++ b/src/test/resources/confluent/marklogic-purchases-source.json
@@ -1,0 +1,18 @@
+{
+  "name": "marklogic-purchases-source",
+  "config": {
+    "connector.class": "com.marklogic.kafka.connect.source.MarkLogicSourceConnector",
+    "key.converter": "org.apache.kafka.connect.storage.StringConverter",
+    "value.converter": "org.apache.kafka.connect.json.JsonConverter",
+    "tasks.max": "1",
+    "ml.connection.host": "localhost",
+    "ml.connection.port": 8018,
+    "ml.connection.username": "kafka-test-user",
+    "ml.connection.password": "kafkatest",
+    "ml.connection.securityContextType": "DIGEST",
+    "ml.source.optic.dsl": "op.fromView('demo', 'purchases')",
+    "ml.source.topic": "marklogic-purchases",
+    "ml.source.waitTime": "10000",
+    "ml.source.optic.jobName": "test-job"
+  }
+}


### PR DESCRIPTION
This isn't complete, but should be enough to help someone get started with QA and kicking the tires on the source connector.

Summary:
- Renamed the Confluent test files so they either end in "-sink" or "-source" to make them more self-documenting
- Added some TODO's to the README where we'll need to fill stuff in later
- Changed ordered in Config classes so that connection properties show up first
- Modified some of the source config props based on language I pulled from the RowBatcher javadoc
- Modified the SourceRecord so that the JSON is stringified; will figure out how to return a JsonNode later
- Added "purchases" TDE for the demo source connector to use
- Changed demo files to use "kafka-test-user"