### PR TITLE
Added fix for known server bug

### DIFF
--- a/src/main/java/com/marklogic/kafka/connect/source/RowBatcherSourceTask.java
+++ b/src/main/java/com/marklogic/kafka/connect/source/RowBatcherSourceTask.java
@@ -66,14 +66,20 @@ public class RowBatcherSourceTask extends SourceTask {
     @Override
     public List<SourceRecord> poll() throws InterruptedException {
         List<SourceRecord> newSourceRecords = new Vector<>();
+        logger.info("Temporary log statement for testing; sleeping for " + pollDelayMs + "ms");
         Thread.sleep(pollDelayMs);
 
-        rowBatcher = getNewRowBatcher(newSourceRecords);
-        performPoll();
-        if (newSourceRecords.size() == 0) {
-            newSourceRecords = null;
+        try {
+            rowBatcher = getNewRowBatcher(newSourceRecords);
+        } catch (FailedRequestException ex) {
+            if (rowBatcherErrorIsKnownServerBug(ex)) {
+                return null;
+            }
+            throw new RuntimeException("Unable to poll for source records; cause: " + ex.getMessage(), ex);
         }
-        return newSourceRecords;
+
+        performPoll();
+        return newSourceRecords.isEmpty() ? null : newSourceRecords;
     }
 
     protected RowBatcher<JsonNode> getNewRowBatcher(List<SourceRecord> newSourceRecords) {
@@ -138,12 +144,7 @@ public class RowBatcherSourceTask extends SourceTask {
         String dslPlan = (String) parsedConfig.get(MarkLogicSourceConfig.DSL_PLAN);
         RowManager rowMgr = rowBatcher.getRowManager();
         RawQueryDSLPlan plan = rowMgr.newRawQueryDSLPlan(new StringHandle(dslPlan));
-        try {
-            rowBatcher.withBatchView(plan);
-        } catch (FailedRequestException ex) {
-            throw new RuntimeException("Unable to poll for source records; cause: " + ex.getMessage(), ex);
-        }
-
+        rowBatcher.withBatchView(plan);
         rowBatcher.onSuccess(event -> onSuccessHandler(event, newSourceRecords));
         rowBatcher.onFailure(this::onFailureHandler);
     }
@@ -165,5 +166,15 @@ public class RowBatcherSourceTask extends SourceTask {
 
     private void onFailureHandler(RowBatchFailureListener.RowBatchFailureEvent batch, Throwable throwable) {
         logger.warn("batch "+batch.getJobBatchNumber()+" failed with error: "+throwable.getMessage());
+    }
+
+    private boolean rowBatcherErrorIsKnownServerBug(FailedRequestException ex) {
+        String serverMessage = ex.getServerMessage();
+        final String knownBugErrorMessage = "$tableId as xs:string -- Invalid coercion: () as xs:string";
+        if (serverMessage != null && serverMessage.contains(knownBugErrorMessage)) {
+            logger.debug("Catching known bug where an error is thrown when no rows exist; will return no data instead");
+            return true;
+        }
+        return false;
     }
 }


### PR DESCRIPTION
Changes:

- Moved the try/catch to `poll()` so that `null` can be returned for a known server bug
- Changed the test to not always load data so it's easier to test the condition where no data exists
- Added another assertion to the "does not start with fromView" test, as it looks like we get a reliable error message for that