### PR TITLE
DEVEXP-95: View recommendations and validation errors for certain sink config properties

### DIFF
--- a/src/test/java/com/marklogic/kafka/connect/BuildDatabaseClientConfigTest.java
+++ b/src/test/java/com/marklogic/kafka/connect/BuildDatabaseClientConfigTest.java
@@ -161,20 +161,142 @@ public class BuildDatabaseClientConfigTest {
 
     @Test
     public void testInvalidAuthentication() {
-        Map<String, Object> config = new HashMap<>();
-        config.put(MarkLogicSinkConfig.CONNECTION_HOST, "");
-        config.put(MarkLogicSinkConfig.CONNECTION_PORT, 8000);
-        config.put(MarkLogicSinkConfig.CONNECTION_SECURITY_CONTEXT_TYPE, "IncorrectValue");
-        ConfigException ex = assertThrows(ConfigException.class, () -> MarkLogicSinkConfig.CONFIG_DEF.parse(config),
+        Map<String, Object> securityContextConfig = new HashMap<>();
+        securityContextConfig.put(MarkLogicSinkConfig.CONNECTION_HOST, "localhost");
+        securityContextConfig.put(MarkLogicSinkConfig.CONNECTION_PORT, 8000);
+        securityContextConfig.put(MarkLogicSinkConfig.CONNECTION_SECURITY_CONTEXT_TYPE, "IncorrectValue");
+        ConfigException ex = assertThrows(ConfigException.class, () -> MarkLogicSinkConfig.CONFIG_DEF.parse(securityContextConfig),
             "Should throw ConfigException when an invalid authentication type is provided.");
         assertEquals("Invalid value: IncorrectValue; must be one of: [DIGEST, BASIC, CERTIFICATE, KERBEROS, NONE]", ex.getMessage());
+    }
+
+    @Test
+    public void invalidDocumentFormatConfig() {
+        Map<String, Object>  documentFormatConfig = new HashMap<>();
+        documentFormatConfig.put(MarkLogicSinkConfig.CONNECTION_HOST, "localhost");
+        documentFormatConfig.put(MarkLogicSinkConfig.CONNECTION_PORT, 8000);
+        documentFormatConfig.put(MarkLogicSinkConfig.DOCUMENT_FORMAT, "InvalidFormat");
+        ConfigException ex = assertThrows(ConfigException.class, () -> MarkLogicSinkConfig.CONFIG_DEF.parse(documentFormatConfig),
+            "Should throw ConfigException when an invalid Document format is provided.");
+        assertEquals("Invalid value: InvalidFormat; must be one of: [JSON, XML, BINARY, TEXT, UNKNOWN, ]", ex.getMessage());
+    }
+
+    @Test
+    public void invalidIdStrategyConfig() {
+        Map<String, Object> idStrategyConfig = new HashMap<>();
+        idStrategyConfig.put(MarkLogicSinkConfig.CONNECTION_HOST, "localhost");
+        idStrategyConfig.put(MarkLogicSinkConfig.CONNECTION_PORT, 8000);
+        idStrategyConfig.put(MarkLogicSinkConfig.ID_STRATEGY, "InvalidStrategy");
+        ConfigException ex = assertThrows(ConfigException.class, () -> MarkLogicSinkConfig.CONFIG_DEF.parse(idStrategyConfig),
+            "Should throw ConfigException when an Id Strategy format is provided.");
+        assertEquals("Invalid value: InvalidStrategy; must be one of: [JSONPATH, HASH, KAFKA_META_HASHED, KAFKA_META_WITH_SLASH, ]", ex.getMessage());
+    }
+
+    @Test
+    public void invalidHostConfig() {
+        Map<String, Object> invalidHostConfig = new HashMap<>();
+        invalidHostConfig.put(MarkLogicSinkConfig.CONNECTION_HOST, "");
+        invalidHostConfig.put(MarkLogicSinkConfig.CONNECTION_PORT, 8000);
+        ConfigException ex = assertThrows(ConfigException.class, () -> MarkLogicSinkConfig.CONFIG_DEF.parse(invalidHostConfig),
+            "Should throw ConfigException when host is empty.");
+        assertEquals("Invalid value  for configuration ml.connection.host: String must be non-empty", ex.getMessage());
+    }
+
+    @Test
+    public void invalidPortConfig() {
+        Map<String, Object> invalidPortConfig = new HashMap<>();
+        invalidPortConfig.put(MarkLogicSinkConfig.CONNECTION_HOST, "localhost");
+        invalidPortConfig.put(MarkLogicSinkConfig.CONNECTION_PORT, null);
+        ConfigException ex = assertThrows(ConfigException.class, () -> MarkLogicSinkConfig.CONFIG_DEF.parse(invalidPortConfig),
+            "Should throw ConfigException when port is empty.");
+        assertEquals("Invalid value null for configuration ml.connection.port: Value must be non-null", ex.getMessage());
+    }
+
+    @Test
+    public void invalidSSLHostVerifierConfig() {
+        Map<String, Object> sslHostVerifierConfig = new HashMap<>();
+        sslHostVerifierConfig.put(MarkLogicSinkConfig.CONNECTION_HOST, "localhost");
+        sslHostVerifierConfig.put(MarkLogicSinkConfig.CONNECTION_PORT, 8000);
+        sslHostVerifierConfig.put(MarkLogicSinkConfig.SSL_HOST_VERIFIER, "InvalidValue");
+        ConfigException ex = assertThrows(ConfigException.class, () -> MarkLogicSinkConfig.CONFIG_DEF.parse(sslHostVerifierConfig),
+            "Should throw ConfigException when port is empty.");
+        assertEquals("Invalid value: InvalidValue; must be one of: [ANY, COMMON, STRICT]", ex.getMessage());
+    }
+
+    @Test
+    public void invalidConnectTypeConfig() {
+        Map<String, Object> connectTypeConfig = new HashMap<>();
+        connectTypeConfig.put(MarkLogicSinkConfig.CONNECTION_HOST, "localhost");
+        connectTypeConfig.put(MarkLogicSinkConfig.CONNECTION_PORT, 8000);
+        connectTypeConfig.put(MarkLogicSinkConfig.CONNECTION_TYPE, "InvalidValue");
+        ConfigException ex = assertThrows(ConfigException.class, () -> MarkLogicSinkConfig.CONFIG_DEF.parse(connectTypeConfig),
+            "Should throw ConfigException when port is empty.");
+        assertEquals("Invalid value: InvalidValue; must be one of: [DIRECT, GATEWAY, ]", ex.getMessage());
+    }
+
+    @Test
+    public void invalidDmsdkConfig() {
+        ConfigException ex = null;
+
+        Map<String, Object> dmsdkNegBatchSizeConfig = new HashMap<>();
+        dmsdkNegBatchSizeConfig.put(MarkLogicSinkConfig.CONNECTION_HOST, "localhost");
+        dmsdkNegBatchSizeConfig.put(MarkLogicSinkConfig.CONNECTION_PORT, 8000);
+        dmsdkNegBatchSizeConfig.put(MarkLogicSinkConfig.DMSDK_BATCH_SIZE, -1);
+        ex = assertThrows(ConfigException.class, () -> MarkLogicSinkConfig.CONFIG_DEF.parse(dmsdkNegBatchSizeConfig),
+            "Should throw ConfigException when an invalid Document format is provided.");
+        assertEquals("Invalid value -1 for configuration ml.dmsdk.batchSize: Value must be at least 1", ex.getMessage());
+
+        Map<String, Object> dmsdkZeroBatchSizeConfig = new HashMap<>();
+        dmsdkZeroBatchSizeConfig.put(MarkLogicSinkConfig.CONNECTION_HOST, "localhost");
+        dmsdkZeroBatchSizeConfig.put(MarkLogicSinkConfig.CONNECTION_PORT, 8000);
+        dmsdkZeroBatchSizeConfig.put(MarkLogicSinkConfig.DMSDK_BATCH_SIZE, 0);
+        ex = assertThrows(ConfigException.class, () -> MarkLogicSinkConfig.CONFIG_DEF.parse(dmsdkZeroBatchSizeConfig),
+            "Should throw ConfigException when an invalid Document format is provided.");
+        assertEquals("Invalid value 0 for configuration ml.dmsdk.batchSize: Value must be at least 1", ex.getMessage());
+
+        Map<String, Object> dmsdkNegThreadCountConfig = new HashMap<>();
+        dmsdkNegThreadCountConfig.put(MarkLogicSinkConfig.CONNECTION_HOST, "localhost");
+        dmsdkNegThreadCountConfig.put(MarkLogicSinkConfig.CONNECTION_PORT, 8000);
+        dmsdkNegThreadCountConfig.put(MarkLogicSinkConfig.DMSDK_THREAD_COUNT, -1);
+        ex = assertThrows(ConfigException.class, () -> MarkLogicSinkConfig.CONFIG_DEF.parse(dmsdkNegThreadCountConfig),
+            "Should throw ConfigException when an invalid Document format is provided.");
+        assertEquals("Invalid value -1 for configuration ml.dmsdk.threadCount: Value must be at least 1", ex.getMessage());
+
+        Map<String, Object> dmsdkZeroThreadCountConfig = new HashMap<>();
+        dmsdkZeroThreadCountConfig.put(MarkLogicSinkConfig.CONNECTION_HOST, "localhost");
+        dmsdkZeroThreadCountConfig.put(MarkLogicSinkConfig.CONNECTION_PORT, 8000);
+        dmsdkZeroThreadCountConfig.put(MarkLogicSinkConfig.DMSDK_THREAD_COUNT, 0);
+        ex = assertThrows(ConfigException.class, () -> MarkLogicSinkConfig.CONFIG_DEF.parse(dmsdkZeroThreadCountConfig),
+            "Should throw ConfigException when an invalid Document format is provided.");
+        assertEquals("Invalid value 0 for configuration ml.dmsdk.threadCount: Value must be at least 1", ex.getMessage());
+    }
+
+    @Test
+    public void invalidBulkDSConfig() {
+        ConfigException ex = null;
+
+        Map<String, Object> negBulkDsBatchSize = new HashMap<>();
+        negBulkDsBatchSize.put(MarkLogicSinkConfig.CONNECTION_HOST, "localhost");
+        negBulkDsBatchSize.put(MarkLogicSinkConfig.CONNECTION_PORT, 8000);
+        negBulkDsBatchSize.put(MarkLogicSinkConfig.BULK_DS_BATCH_SIZE, -1);
+        ex = assertThrows(ConfigException.class, () -> MarkLogicSinkConfig.CONFIG_DEF.parse(negBulkDsBatchSize),
+            "Should throw ConfigException when an invalid Document format is provided.");
+        assertEquals("Invalid value -1 for configuration ml.sink.bulkds.batchSize: Value must be at least 1", ex.getMessage());
+
+        Map<String, Object> zeroBulkDsBatchSize = new HashMap<>();
+        zeroBulkDsBatchSize.put(MarkLogicSinkConfig.CONNECTION_HOST, "localhost");
+        zeroBulkDsBatchSize.put(MarkLogicSinkConfig.CONNECTION_PORT, 8000);
+        zeroBulkDsBatchSize.put(MarkLogicSinkConfig.BULK_DS_BATCH_SIZE, 0);
+        ex = assertThrows(ConfigException.class, () -> MarkLogicSinkConfig.CONFIG_DEF.parse(zeroBulkDsBatchSize),
+            "Should throw ConfigException when an invalid Document format is provided.");
+        assertEquals("Invalid value 0 for configuration ml.sink.bulkds.batchSize: Value must be at least 1", ex.getMessage());
     }
 
     @Test
     // This also implicitly verifies that all other sink properties are optional
     public void testMissingRequired() {
         Map<String, Object> allRequiredValuesConfig = new HashMap<>();
-        allRequiredValuesConfig.put(MarkLogicSinkConfig.CONNECTION_HOST, "");
+        allRequiredValuesConfig.put(MarkLogicSinkConfig.CONNECTION_HOST, "localhost");
         allRequiredValuesConfig.put(MarkLogicSinkConfig.CONNECTION_PORT, 8000);
         MarkLogicSinkConfig.CONFIG_DEF.parse(allRequiredValuesConfig);
 


### PR DESCRIPTION
For a property with recommenders and validators, when the ConfigDef.NO_DEFAULT_VALUE is used as the default value, the property is becoming a required property in the ConfigDef. So I used an empty string as the default value.