### PR TITLE
Added Recommended for output format, plus logging

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -224,7 +224,11 @@ task loadMarkLogicPurchasesSourceConnector(type: Exec, group: confluentTestingGr
 task setupLocalConfluent(group: confluentTestingGroup) {
   description = "Start a local Confluent Platform instance and load the Datagen and MarkLogic connectors"
 }
-setupLocalConfluent.dependsOn startLocalConfluent, loadDatagenPurchasesConnector, loadMarkLogicPurchasesSinkConnector, loadMarkLogicPurchasesSourceConnector
+
+// Temporarily only loading the source connector to make manual testing easier, will re-enable all of these before 1.8.0
+//setupLocalConfluent.dependsOn startLocalConfluent, loadDatagenPurchasesConnector, loadMarkLogicPurchasesSinkConnector, loadMarkLogicPurchasesSourceConnector
+setupLocalConfluent.dependsOn startLocalConfluent, loadMarkLogicPurchasesSourceConnector
+
 loadDatagenPurchasesConnector.mustRunAfter startLocalConfluent
 loadMarkLogicPurchasesSinkConnector.mustRunAfter startLocalConfluent
 loadMarkLogicPurchasesSourceConnector.mustRunAfter startLocalConfluent

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,4 +22,4 @@ mlTestRestPort=8019
 mlAppName=kafka-test
 mlUsername=admin
 mlPassword=changeme-in-gradle-local.properties
-mlContentForestsPerHost=1
+mlContentForestsPerHost=2

--- a/src/test/resources/confluent/datagen-purchases-source.json
+++ b/src/test/resources/confluent/datagen-purchases-source.json
@@ -8,7 +8,7 @@
     "value.converter": "org.apache.kafka.connect.json.JsonConverter",
     "value.converter.schemas.enable": "false",
     "value.converter.decimal.format": "NUMERIC",
-    "max.interval": 1000,
+    "max.interval": 5000,
     "tasks.max": "1"
   }
 }

--- a/src/test/resources/confluent/marklogic-purchases-source.json
+++ b/src/test/resources/confluent/marklogic-purchases-source.json
@@ -12,7 +12,10 @@
     "ml.connection.securityContextType": "DIGEST",
     "ml.source.optic.dsl": "op.fromView('demo', 'purchases')",
     "ml.source.topic": "marklogic-purchases",
-    "ml.source.waitTime": "10000",
-    "ml.source.optic.jobName": "test-job"
+    "ml.source.waitTime": "5000",
+    "ml.source.optic.jobName": "test-job",
+    "ml.source.optic.outputFormat": "JSON",
+    "ml.dmsdk.batchSize": "100000",
+    "ml.dmsdk.threadCount": "16"
   }
 }


### PR DESCRIPTION
Made a few changes to make manual testing easier for now - disabled the datagen/sink connectors until we want to test them again; added a second forest to the test app for more realistic performance testing; tweaked the source connector to make it easier to test. 

Some of the logging additions will likely be removed, just added them to again make manual testing in CP easier for now. 