### PR TITLE
Making TransformerFactory thread-safe

### DIFF
--- a/src/test/resources/confluent/marklogic-purchases-source.json
+++ b/src/test/resources/confluent/marklogic-purchases-source.json
@@ -15,7 +15,7 @@
     "ml.source.waitTime": "5000",
     "ml.source.optic.jobName": "test-job",
     "ml.source.optic.outputFormat": "JSON",
-    "ml.dmsdk.batchSize": "100000",
+    "ml.dmsdk.batchSize": "10000",
     "ml.dmsdk.threadCount": "16"
   }
 }


### PR DESCRIPTION
Also changed default batch size in marklogic-purchases-source to match what's in MarkLogicSourceConfig