### PR TITLE
Logging tweaks, plus new testing tool for inserting authors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -190,6 +190,14 @@ following:
 See [the log command docs](https://docs.confluent.io/confluent-cli/current/command-reference/local/services/connect/confluent_local_services_connect_log.html)
 for more information.
 
+You can also customize Confluent logging by [adjusting the log4j file for Kafka Connect](https://docs.confluent.io/platform/current/connect/logging.html#viewing-kconnect-logs).
+For example, to prevent some logging from Kafka Connect and from the Java Client DMSDK, add the following to the 
+`$CONFLUENT_HOME/etc/kafka/connect-log4j.properties` file:
+
+    log4j.logger.org.apache.kafka=WARN
+    log4j.logger.com.marklogic.client.datamovement=WARN
+
+
 ## Destroying and setting up the Confluent Platform instance
 
 While developing and testing the MarkLogic Kafka connector, it is common that the "local" instance of Confluent 

--- a/build.gradle
+++ b/build.gradle
@@ -35,16 +35,15 @@ dependencies {
   compileOnly "org.apache.kafka:connect-runtime:${kafkaVersion}"
   compileOnly "org.slf4j:slf4j-api:1.7.36"
 
-  // The latest jackson libraries can be removed once the marklogic-client is upgraded to include them.
-  implementation 'com.fasterxml.jackson.core:jackson-core:2.13.4'
-  implementation 'com.fasterxml.jackson.core:jackson-annotations:2.13.4'
-  implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.4.2'
-  implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-csv:2.13.4'
-
   implementation "com.marklogic:marklogic-client-api:6.0.0"
+
+  implementation ("com.marklogic:ml-javaclient-util:4.4.0") {
+    exclude module: "marklogic-client-api"
+  }
 
   implementation("com.marklogic:marklogic-data-hub:5.7.2") {
     exclude module: "marklogic-client-api"
+    exclude module: "ml-javaclient-util"
 
     // Excluding these because there's no need for them
     exclude module: "spring-boot-autoconfigure"
@@ -248,3 +247,10 @@ loadMarkLogicPurchasesSinkConnector.mustRunAfter startLocalConfluent
 loadMarkLogicPurchasesSourceConnector.mustRunAfter startLocalConfluent
 loadMarkLogicAuthorsSourceConnector.mustRunAfter startLocalConfluent
 
+task insertAuthor(type: Test) {
+  useJUnitPlatform()
+  systemProperty "AUTHOR_IDS", authorIds
+  description = "Insert a new author into the kafka-test-content database via a new citations XML document; " +
+    "use e.g. -PauthorIds=7,8,9 to insert 3 new authors with IDs of 7, 8, and 9"
+  include "com/marklogic/kafka/connect/source/debug/InsertAuthors.class"
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,3 +24,7 @@ mlAppName=kafka-test
 mlUsername=admin
 mlPassword=changeme-in-gradle-local.properties
 mlContentForestsPerHost=2
+
+# For inserting new authors during manual testing; set this to a comma-delimited string of numbers
+# e.g. -PauthorIds=7,8,9
+authorIds=

--- a/src/main/java/com/marklogic/kafka/connect/source/SerializedQueryHandler.java
+++ b/src/main/java/com/marklogic/kafka/connect/source/SerializedQueryHandler.java
@@ -39,6 +39,7 @@ public class SerializedQueryHandler extends LoggingObject implements QueryHandle
     @Override
     public void addQueryToRowBatcher(RowBatcher<?> rowBatcher, String previousMaxConstraintColumnValue) {
         currentSerializedQuery = injectConstraintIntoQuery(previousMaxConstraintColumnValue);
+        logger.info("Serialized query: " + currentSerializedQuery);
         RowManager rowMgr = rowBatcher.getRowManager();
         RawPlanDefinition query = rowMgr.newRawPlanDefinition(new StringHandle(currentSerializedQuery));
         rowBatcher.withBatchView(query);
@@ -60,7 +61,6 @@ public class SerializedQueryHandler extends LoggingObject implements QueryHandle
                 throw new RuntimeException("Unable to modify serialized query to include the constraint column, cause: " + e.getMessage(), e);
             }
         }
-        logger.debug("Serialized constrainedQuery (unless initial run): " + constrainedSerialized);
         return constrainedSerialized;
     }
 
@@ -68,10 +68,10 @@ public class SerializedQueryHandler extends LoggingObject implements QueryHandle
     public String updatePreviousMaxConstraintColumnValue(long queryStartTimeInMillis) {
         String previousMaxConstraintColumnValue = null;
         try {
-            String currentMaxValueQuery = buildMaxValueSerializedQuery();
-            logger.debug("currentMaxValueQuery: " + currentMaxValueQuery);
+            String maxValueQuery = buildMaxValueSerializedQuery();
+            logger.info("Query for max constraint value: " + maxValueQuery);
             RowManager rowMgr = databaseClient.newRowManager();
-            RawPlanDefinition maxConstraintValueQuery = rowMgr.newRawPlanDefinition(new StringHandle(currentMaxValueQuery));
+            RawPlanDefinition maxConstraintValueQuery = rowMgr.newRawPlanDefinition(new StringHandle(maxValueQuery));
             JacksonHandle handle = new JacksonHandle().withFormat(Format.JSON).withMimetype("application/json");
             handle.setPointInTimeQueryTimestamp(queryStartTimeInMillis);
             JacksonHandle result = rowMgr.resultDoc(maxConstraintValueQuery, handle);

--- a/src/test/java/com/marklogic/kafka/connect/source/debug/InsertAuthors.java
+++ b/src/test/java/com/marklogic/kafka/connect/source/debug/InsertAuthors.java
@@ -1,0 +1,87 @@
+package com.marklogic.kafka.connect.source.debug;
+
+import com.marklogic.client.DatabaseClient;
+import com.marklogic.client.document.DocumentWriteSet;
+import com.marklogic.client.document.XMLDocumentManager;
+import com.marklogic.client.ext.DatabaseClientConfig;
+import com.marklogic.client.ext.DefaultConfiguredDatabaseClientFactory;
+import com.marklogic.client.io.DocumentMetadataHandle;
+import com.marklogic.client.io.Format;
+import com.marklogic.client.io.StringHandle;
+import com.marklogic.junit5.spring.SimpleTestConfig;
+import com.marklogic.kafka.connect.AbstractIntegrationTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Convenience program for inserting a new author into the kafka-test-content database to facilitate testing the
+ * source connector on the authors TDE. This reuses the test plumbing so we don't have to collect host/port/etc
+ * information, but it adjusts the DatabaseClient config to use port 8018 instead of 8019 so that documents are
+ * inserted into the kafka-test-content database instead of kafka-test-test-content.
+ */
+public class InsertAuthors extends AbstractIntegrationTest {
+
+    // Only intended for inserting new authors with a user-provided ID. Can easily expand this to make the data more
+    // random and/or controlled by the user.
+    private final static String CITATIONS_DOC = "<Citations>\n" +
+        "  <Citation>\n" +
+        "    <ID>%%AUTHOR_ID%%</ID>\n" +
+        "    <Article>\n" +
+        "      <Journal>\n" +
+        "        <ISSN>61296-004</ISSN>\n" +
+        "        <JournalIssue>\n" +
+        "          <Volume>44</Volume>\n" +
+        "          <PubDate>\n" +
+        "            <Date>2022-07-13</Date>\n" +
+        "            <Year>2022</Year>\n" +
+        "            <Month>07</Month>\n" +
+        "            <Day>13</Day>\n" +
+        "            <Time>09:00:00</Time>\n" +
+        "          </PubDate>\n" +
+        "        </JournalIssue>\n" +
+        "      </Journal>\n" +
+        "      <AuthorList>\n" +
+        "        <Author>\n" +
+        "          <LastName>LastName%%AUTHOR_ID%%</LastName>\n" +
+        "          <ForeName>ForeName%%AUTHOR_ID%%</ForeName>\n" +
+        "        </Author>\n" +
+        "      </AuthorList>\n" +
+        "    </Article>\n" +
+        "  </Citation>\n" +
+        "</Citations>\n";
+
+    @Autowired
+    SimpleTestConfig testConfig;
+
+    @Test
+    void insertAuthors() {
+        final String authorIds = System.getProperty("AUTHOR_IDS");
+        if (authorIds == null || authorIds.trim().length() < 1) {
+            System.out.println("Please specify AUTHOR_IDS as a system property containing a comma-delimited list of author IDs; \n" +
+                "if running this via Gradle, use -PauthorId=someNumber to specify the value");
+            return;
+        }
+
+        DatabaseClientConfig config = testConfig.databaseClientConfig();
+        config.setPort(8018);
+        DatabaseClient client = new DefaultConfiguredDatabaseClientFactory().newDatabaseClient(config);
+
+        XMLDocumentManager mgr = client.newXMLDocumentManager();
+        DocumentWriteSet writeSet = mgr.newWriteSet();
+        List<String> uris = new ArrayList<>();
+        DocumentMetadataHandle metadata = new DocumentMetadataHandle()
+            .withPermission("kafka-test-minimal-user", DocumentMetadataHandle.Capability.READ, DocumentMetadataHandle.Capability.UPDATE);
+
+        for (String authorId : authorIds.split(",")) {
+            final String uri = "/citation/author/" + authorId + ".xml";
+            uris.add(uri);
+            String xml = CITATIONS_DOC.replaceAll("%%AUTHOR_ID%%", authorId);
+            writeSet.add(uri, metadata, new StringHandle(xml).withFormat(Format.XML));
+        }
+        mgr.write(writeSet);
+        System.out.println("Successfully inserted new authors with URIs: " + uris);
+    }
+}


### PR DESCRIPTION
Can use `./gradlew insertAuthors -PauthorIds=6,7,8` to quickly insert new authors with user-defined IDs. 