### PR TITLE
Switching from RowBatcher to RowManager

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,7 @@ pipeline{
   stages{
     stage('tests'){
       steps{
-        copyRPM 'Release','10.0-9.4'
+        copyRPM 'Latest','11.0'
         setUpML '$WORKSPACE/xdmp/src/Mark*.rpm'
         sh label:'setup', script: '''#!/bin/bash
         cd kafka-connector

--- a/build.gradle
+++ b/build.gradle
@@ -234,18 +234,24 @@ task loadMarkLogicAuthorsSourceConnector(type: Exec, group: confluentTestingGrou
     "src/test/resources/confluent/marklogic-authors-source.json"
 }
 
+task loadMarkLogicEmployeesSourceConnector(type: Exec, group: confluentTestingGroup) {
+  commandLine "confluent", "local", "services", "connect", "connector", "load", "marklogic-employees-source", "-c",
+    "src/test/resources/confluent/marklogic-employees-source.json"
+}
+
 task setupLocalConfluent(group: confluentTestingGroup) {
   description = "Start a local Confluent Platform instance and load the Datagen and MarkLogic connectors"
 }
 
 // Temporarily only loading the source connector to make manual testing easier, will re-enable all of these before 1.8.0
 //setupLocalConfluent.dependsOn startLocalConfluent, loadDatagenPurchasesConnector, loadMarkLogicPurchasesSinkConnector, loadMarkLogicPurchasesSourceConnector
-setupLocalConfluent.dependsOn startLocalConfluent, loadMarkLogicAuthorsSourceConnector
+setupLocalConfluent.dependsOn startLocalConfluent, loadMarkLogicEmployeesSourceConnector
 
 loadDatagenPurchasesConnector.mustRunAfter startLocalConfluent
 loadMarkLogicPurchasesSinkConnector.mustRunAfter startLocalConfluent
 loadMarkLogicPurchasesSourceConnector.mustRunAfter startLocalConfluent
 loadMarkLogicAuthorsSourceConnector.mustRunAfter startLocalConfluent
+loadMarkLogicEmployeesSourceConnector.mustRunAfter startLocalConfluent
 
 task insertAuthor(type: Test) {
   useJUnitPlatform()

--- a/src/main/java/com/marklogic/kafka/connect/source/CsvPlanInvoker.java
+++ b/src/main/java/com/marklogic/kafka/connect/source/CsvPlanInvoker.java
@@ -1,0 +1,44 @@
+package com.marklogic.kafka.connect.source;
+
+import com.marklogic.client.DatabaseClient;
+import com.marklogic.client.expression.PlanBuilder;
+import com.marklogic.client.io.Format;
+import com.marklogic.client.io.StringHandle;
+import org.apache.kafka.connect.source.SourceRecord;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.List;
+
+class CsvPlanInvoker implements PlanInvoker {
+
+    private DatabaseClient client;
+
+    public CsvPlanInvoker(DatabaseClient client) {
+        this.client = client;
+    }
+
+    @Override
+    public Results invokePlan(PlanBuilder.Plan plan, String topic) {
+        StringHandle baseHandle = new StringHandle().withFormat(Format.TEXT).withMimetype("text/csv");
+        StringHandle result = client.newRowManager().resultDoc(plan, baseHandle);
+        List<SourceRecord> records = new ArrayList<>();
+
+        if (result.get() != null) {
+            try (BufferedReader reader = new BufferedReader(new StringReader(result.get()))) {
+                String headers = reader.readLine();
+                reader.lines().forEach(line -> {
+                    String newDocument = headers + "\n" + line;
+                    SourceRecord newRecord = new SourceRecord(null, null, topic, null, newDocument);
+                    records.add(newRecord);
+                });
+            } catch (IOException ex) {
+                throw new RuntimeException("Unable to parse CSV results: " + ex.getMessage(), ex);
+            }
+        }
+
+        return new Results(records, baseHandle.getServerTimestamp());
+    }
+}

--- a/src/main/java/com/marklogic/kafka/connect/source/JsonPlanInvoker.java
+++ b/src/main/java/com/marklogic/kafka/connect/source/JsonPlanInvoker.java
@@ -1,0 +1,39 @@
+package com.marklogic.kafka.connect.source;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.marklogic.client.DatabaseClient;
+import com.marklogic.client.expression.PlanBuilder;
+import com.marklogic.client.io.JacksonHandle;
+import org.apache.kafka.connect.source.SourceRecord;
+
+import java.util.ArrayList;
+import java.util.List;
+
+class JsonPlanInvoker implements PlanInvoker {
+
+    private DatabaseClient client;
+
+    public JsonPlanInvoker(DatabaseClient client) {
+        this.client = client;
+    }
+
+    @Override
+    public Results invokePlan(PlanBuilder.Plan plan, String topic) {
+        JacksonHandle baseHandle = new JacksonHandle();
+        JacksonHandle result = client.newRowManager().resultDoc(plan, baseHandle);
+        List<SourceRecord> records = new ArrayList<>();
+        /**
+         * Testing has shown that converting the JSON to a string and using
+         * org.apache.kafka.connect.storage.StringConverter as the value converter works well. And a user could
+         * still choose to use org.apache.kafka.connect.json.JsonConverter, though they would most likely want
+         * to set "value.converter.schemas.enable" to "false".
+         */
+        JsonNode doc = result.get();
+        if (doc != null && doc.has("rows")) {
+            for (JsonNode row : doc.get("rows")) {
+                records.add(new SourceRecord(null, null, topic, null, row.toString()));
+            }
+        }
+        return new Results(records, baseHandle.getServerTimestamp());
+    }
+}

--- a/src/main/java/com/marklogic/kafka/connect/source/PlanInvoker.java
+++ b/src/main/java/com/marklogic/kafka/connect/source/PlanInvoker.java
@@ -1,0 +1,67 @@
+package com.marklogic.kafka.connect.source;
+
+import com.marklogic.client.DatabaseClient;
+import com.marklogic.client.expression.PlanBuilder;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Strategy interface for how a plan is invoked; "invoke" is the chosen term per the docs at
+ * https://docs.marklogic.com/REST/POST/v1/rows .
+ */
+public interface PlanInvoker {
+
+    /**
+     * Invoke the given plan, returning a Results object containing source records that should be associated with
+     * the given topic.
+     *
+     * @param plan
+     * @param topic
+     * @return
+     */
+    Results invokePlan(PlanBuilder.Plan plan, String topic);
+
+    /**
+     * Primary purpose of the class is to transfer the source records along with the MarkLogic server timestamp at
+     * which the Plan was invoked, thus allowing for the max value of a particular column to be calculated using that
+     * same timestamp.
+     */
+    class Results {
+        private List<SourceRecord> sourceRecords;
+        private long serverTimestamp;
+
+        public Results(List<SourceRecord> sourceRecords, long serverTimestamp) {
+            this.sourceRecords = sourceRecords;
+            this.serverTimestamp = serverTimestamp;
+        }
+
+        public List<SourceRecord> getSourceRecords() {
+            return sourceRecords;
+        }
+
+        public long getServerTimestamp() {
+            return serverTimestamp;
+        }
+    }
+
+    static PlanInvoker newPlanInvoker(DatabaseClient client, Map<String, Object> parsedConfig) {
+        String format = (String) parsedConfig.get(MarkLogicSourceConfig.OUTPUT_FORMAT);
+        MarkLogicSourceConfig.OUTPUT_TYPE outputType = StringUtils.hasText(format) ?
+            MarkLogicSourceConfig.OUTPUT_TYPE.valueOf(format) :
+            MarkLogicSourceConfig.OUTPUT_TYPE.JSON;
+
+        switch (outputType) {
+            case JSON:
+                return new JsonPlanInvoker(client);
+            case CSV:
+                return new CsvPlanInvoker(client);
+            case XML:
+                return new XmlPlanInvoker(client);
+            default:
+                throw new IllegalArgumentException("Unexpected output type: " + outputType);
+        }
+    }
+}

--- a/src/main/java/com/marklogic/kafka/connect/source/XmlPlanInvoker.java
+++ b/src/main/java/com/marklogic/kafka/connect/source/XmlPlanInvoker.java
@@ -1,0 +1,74 @@
+package com.marklogic.kafka.connect.source;
+
+import com.marklogic.client.DatabaseClient;
+import com.marklogic.client.expression.PlanBuilder;
+import com.marklogic.client.io.DOMHandle;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.List;
+
+class XmlPlanInvoker implements PlanInvoker {
+
+    private static final String TABLE_NS_URI = "http://marklogic.com/table";
+
+    // While a Transformer is not thread-safe and must therefore be created for each batch - though we could consider
+    // a pooling strategy in the future - a TransformerFactory is thread-safe and can thus be reused
+    private static final TransformerFactory transformerFactory = TransformerFactory.newInstance();
+
+    private DatabaseClient client;
+
+    public XmlPlanInvoker(DatabaseClient client) {
+        this.client = client;
+    }
+
+    @Override
+    public Results invokePlan(PlanBuilder.Plan plan, String topic) {
+        DOMHandle baseHandle = new DOMHandle();
+        DOMHandle result = client.newRowManager().resultDoc(plan, baseHandle);
+        List<SourceRecord> records = result.get() != null ?
+            convertRowsToSourceRecords(result, topic) :
+            new ArrayList<>();
+        return new Results(records, baseHandle.getServerTimestamp());
+    }
+
+    private List<SourceRecord> convertRowsToSourceRecords(DOMHandle result, String topic) {
+        Element docElement = result.get().getDocumentElement();
+        NodeList rows = docElement.getElementsByTagNameNS(TABLE_NS_URI, "row");
+
+        Transformer transformer;
+        try {
+            transformer = transformerFactory.newTransformer();
+            transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
+        } catch (Exception ex) {
+            throw new RuntimeException("Unable to create XML transformer: " + ex.getMessage(), ex);
+        }
+
+        List<SourceRecord> records = new ArrayList<>();
+        for (int i = 0; i < rows.getLength(); i++) {
+            SourceRecord newRecord = new SourceRecord(null, null, topic, null, documentToString(rows.item(i), transformer));
+            records.add(newRecord);
+        }
+        return records;
+    }
+
+    private String documentToString(Node newDoc, Transformer transformer) {
+        try {
+            StringWriter sw = new StringWriter();
+            transformer.transform(new DOMSource(newDoc), new StreamResult(sw));
+            return sw.toString();
+        } catch (TransformerException ex) {
+            throw new RuntimeException("Unable to transform XML to string: " + ex.getMessage(), ex);
+        }
+    }
+}

--- a/src/test/java/com/marklogic/kafka/connect/source/ReadCsvRowsTest.java
+++ b/src/test/java/com/marklogic/kafka/connect/source/ReadCsvRowsTest.java
@@ -2,8 +2,11 @@ package com.marklogic.kafka.connect.source;
 
 import org.apache.kafka.connect.source.SourceRecord;
 import org.junit.jupiter.api.Test;
+import scala.Int;
 
 import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 class ReadCsvRowsTest extends AbstractIntegrationSourceTest {
     protected final String CSV_RESULT = "Medical.Authors.ID,Medical.Authors.LastName,Medical.Authors.ForeName,Medical.Authors.Date,Medical.Authors.DateTime\n" +
@@ -22,4 +25,18 @@ class ReadCsvRowsTest extends AbstractIntegrationSourceTest {
         List<SourceRecord> newSourceRecords = task.poll();
         verifyQueryReturnsFifteenAuthors(newSourceRecords, CSV_RESULT);
     }
+
+    @Test
+    void noMatchingRows() throws InterruptedException {
+        RowBatcherSourceTask task = startSourceTask(
+            MarkLogicSourceConfig.DSL_QUERY, AUTHORS_OPTIC_DSL,
+            MarkLogicSourceConfig.TOPIC, AUTHORS_TOPIC,
+            MarkLogicSourceConfig.OUTPUT_FORMAT, MarkLogicSourceConfig.OUTPUT_TYPE.CSV.toString()
+        );
+
+        List<SourceRecord> records = task.poll();
+        assertNull(records, "Should get null back when no rows match; also, check the logging to ensure that " +
+            "no exception was thrown");
+    }
+
 }

--- a/src/test/java/com/marklogic/kafka/connect/source/ReadXmlRowsTest.java
+++ b/src/test/java/com/marklogic/kafka/connect/source/ReadXmlRowsTest.java
@@ -5,6 +5,8 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertNull;
+
 class ReadXmlRowsTest extends AbstractIntegrationSourceTest {
     protected final String XML_RESULT = "<t:row xmlns:t=\"http://marklogic.com/table\">\n" +
         "<t:cell name=\"Medical.Authors.ID\" type=\"xs:integer\">2</t:cell>\n" +
@@ -26,5 +28,17 @@ class ReadXmlRowsTest extends AbstractIntegrationSourceTest {
 
         List<SourceRecord> newSourceRecords = task.poll();
         verifyQueryReturnsFifteenAuthors(newSourceRecords, XML_RESULT);
+    }
+
+    @Test
+    void noMatchingRows() throws InterruptedException {
+        List<SourceRecord> records = startSourceTask(
+            MarkLogicSourceConfig.DSL_QUERY, "op.fromDocUris(cts.documentQuery('no-such-document'))",
+            MarkLogicSourceConfig.TOPIC, AUTHORS_TOPIC,
+            MarkLogicSourceConfig.OUTPUT_FORMAT, MarkLogicSourceConfig.OUTPUT_TYPE.XML.toString()
+        ).poll();
+
+        assertNull(records, "Should get null back when no rows match; also, check the logging to ensure that " +
+            "no exception was thrown");
     }
 }

--- a/src/test/resources/confluent/marklogic-employees-source.json
+++ b/src/test/resources/confluent/marklogic-employees-source.json
@@ -1,0 +1,22 @@
+{
+  "name": "marklogic-employees-source",
+  "config": {
+    "connector.class": "com.marklogic.kafka.connect.source.MarkLogicSourceConnector",
+    "key.converter": "org.apache.kafka.connect.storage.StringConverter",
+    "value.converter": "org.apache.kafka.connect.storage.StringConverter",
+    "tasks.max": "1",
+    "ml.connection.host": "localhost",
+    "ml.connection.port": 8018,
+    "ml.connection.username": "admin",
+    "ml.connection.password": "admin",
+    "ml.connection.securityContextType": "DIGEST",
+    "ml.source.optic.dsl": "op.fromView('demo', 'employee').orderBy(op.asc('incrementing_id'))",
+    "ml.source.optic.constraintColumn.name": "incrementing_id",
+    "ml.source.optic.constraintColumn.uri": "/employee-kafka-data.json",
+    "ml.source.optic.constraintColumn.collections": "kafka-config",
+    "ml.source.optic.constraintColumn.permissions": "rest-reader,read,rest-writer,update",
+    "ml.source.topic": "marklogic-employees",
+    "ml.source.waitTime": "3000",
+    "ml.source.optic.outputFormat": "JSON"
+  }
+}


### PR DESCRIPTION
Consensus was that the downsides of RowBatcher - can only use fromView; errors happening in the background; confusion over what "batchSize" refers to - were not worth the potential benefit in performance. That's because once RowBatcher is noticeably faster than RowManager, the user is likely pulling back enough rows to run out of memory / Java heap space due to a massive List. 

This leaves all the RowBatcher support in place for now. Main addition is a `PlanInvoker` that does what `RowBatcherBuilder` effectively did, which is to choose the correct handle, invoke a plan, and convert the results into source records. 

Once this is merged, I'll submit a PR to remove all the RB support and rename the task to RowManagerSourceTask. Having that all in one commit/PR will make it easy to pull from if we decide to add RB support back in the future. 