### PR TITLE
Accessor tests

### DIFF
--- a/src/main/java/com/marklogic/kafka/connect/source/DslQueryHandler.java
+++ b/src/main/java/com/marklogic/kafka/connect/source/DslQueryHandler.java
@@ -12,6 +12,7 @@ import org.springframework.util.StringUtils;
 
 import java.util.Map;
 
+
 public class DslQueryHandler extends LoggingObject implements QueryHandler {
 
     private final DatabaseClient databaseClient;
@@ -49,9 +50,12 @@ public class DslQueryHandler extends LoggingObject implements QueryHandler {
 
     protected String appendConstraintAndOrderByToQuery(String previousMaxConstraintColumnValue) {
         String constrainedDsl = userDslQuery;
-        if (previousMaxConstraintColumnValue != null) {
-            String constraintPhrase = ".where(op.gt(op.col('" + constraintColumnName + "'), '" + previousMaxConstraintColumnValue + "'))"
-                + ".orderBy(op.asc('" + constraintColumnName + "'))";
+        if (constraintColumnName != null) {
+            String constraintPhrase = "";
+            if (previousMaxConstraintColumnValue != null) {
+                constraintPhrase += ".where(op.gt(op.col('" + constraintColumnName + "'), '" + previousMaxConstraintColumnValue + "'))";
+            }
+            constraintPhrase += ".orderBy(op.asc('" + constraintColumnName + "'))";
             constrainedDsl = userDslQuery + constraintPhrase;
         }
         return constrainedDsl;

--- a/src/main/java/com/marklogic/kafka/connect/source/RowManagerSourceTask.java
+++ b/src/main/java/com/marklogic/kafka/connect/source/RowManagerSourceTask.java
@@ -112,4 +112,14 @@ public class RowManagerSourceTask extends SourceTask {
         }
         return null;
     }
+
+
+    /**
+     * Exists only for testing.
+     *
+     * @param constraintValueStore
+     */
+    protected void setConstraintValueStore(ConstraintValueStore constraintValueStore) {
+        this.constraintValueStore = constraintValueStore;
+    }
 }

--- a/src/test/java/com/marklogic/kafka/connect/source/DslConstraintInjectionPollTest.java
+++ b/src/test/java/com/marklogic/kafka/connect/source/DslConstraintInjectionPollTest.java
@@ -114,7 +114,7 @@ class DslConstraintInjectionPollTest extends AbstractIntegrationSourceTest {
             "The max value after polling once should be equal to the initial time");
         assertEquals(1, newRecords.size());
         String initialRow = (String) newRecords.get(0).value();
-        assertTrue(initialRow.contains("Initial"));
+        assertTrue(initialRow.contains("Initial"), "Did not find 'Initial' in: " + initialRow);
 
         //    3) Insert a second document with a dateTime greater than that of the first row,
         String laterTime = "02:01:00";
@@ -134,7 +134,7 @@ class DslConstraintInjectionPollTest extends AbstractIntegrationSourceTest {
             "The max value after polling once should be equal to the initial time");
         assertEquals(1, newRecords.size());
         String laterRow = (String) newRecords.get(0).value();
-        assertTrue(laterRow.contains("Later"));
+        assertTrue(laterRow.contains("Later"), "Did not find 'Later' in: " + laterRow);
     }
 
     @Test

--- a/src/test/java/com/marklogic/kafka/connect/source/DslConstraintInjectionTest.java
+++ b/src/test/java/com/marklogic/kafka/connect/source/DslConstraintInjectionTest.java
@@ -1,39 +1,116 @@
 package com.marklogic.kafka.connect.source;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 class DslConstraintInjectionTest extends AbstractIntegrationSourceTest {
-    private static final String constraintColumn = "lucky_number";
-    private static final String constraintValue = "52";
+    private static final String CONSTRAINT_COLUMN = "ID";
+    private static final String CONSTRAINT_VALUE = "2";
+    private static final Map<String, Object> parsedConfig = new HashMap<String, Object>() {{
+        put(MarkLogicSourceConfig.CONSTRAINT_COLUMN_NAME, CONSTRAINT_COLUMN);
+        put(MarkLogicSourceConfig.OUTPUT_FORMAT, MarkLogicSourceConfig.OUTPUT_TYPE.JSON.toString());
+        put(MarkLogicSourceConfig.ROW_LIMIT, 1000);
+    }};
 
     @Test
     void testAccessorOnlyQuery() {
-        String originalDsl = "op.fromView(\"Medical\", \"Authors\")";
-        Map<String, Object> parsedConfig = new HashMap<String, Object>() {{
-            put(MarkLogicSourceConfig.DSL_QUERY, originalDsl);
-            put(MarkLogicSourceConfig.CONSTRAINT_COLUMN_NAME, constraintColumn);
-        }};
-        DslQueryHandler dslQueryHandler = new DslQueryHandler(null, parsedConfig);
-        String expectedValue = "op.fromView(\"Medical\", \"Authors\").where(op.gt(op.col('" + constraintColumn + "'), '" + constraintValue + "')).orderBy(op.asc('" + constraintColumn + "'))";
-        Assertions.assertEquals(expectedValue, dslQueryHandler.appendConstraintAndOrderByToQuery(constraintValue));
+        String userDsl = "op.fromView('Medical','Authors')";
+        String expectedValue = userDsl + ".where(op.gt(op.col('ID'), '2')).orderBy(op.asc('ID'))";
+        assertEquals(expectedValue, appendConstraintOntoQuery(userDsl, parsedConfig, "2"));
     }
 
     @Test
-    void testQueryWithLimit() {
-        String originalDsl = "op.fromView(\"Medical\", \"Authors\")";
-        Map<String, Object> parsedConfig = new HashMap<String, Object>() {{
-            put(MarkLogicSourceConfig.DSL_QUERY, originalDsl);
-            put(MarkLogicSourceConfig.CONSTRAINT_COLUMN_NAME, constraintColumn);
+    void wordQueryWithPhraseAndFollowOnFunction() {
+        String userDsl = "op.fromDocUris(cts.wordQuery('my phrase').joinDoc('abc'))";
+        String expectedResult = userDsl + ".where(op.gt(op.col('ID'), '2')).orderBy(op.asc('ID'))";
+        assertEquals(expectedResult, appendConstraintOntoQuery(userDsl, parsedConfig, "2"),
+            "The where clause should have been injected just after the closing paren of the fromDocUris function");
+    }
+
+    @Test
+    void wordQueryWithOrderBy() {
+        String userDsl = "op.fromDocUris(cts.wordQuery('my phrase'))";
+        String expectedResult = userDsl + ".where(op.gt(op.col('uri'), '2')).orderBy(op.asc('uri'))";
+        Map<String, Object> localParsedConfig = new HashMap<String, Object>() {{
+            put(MarkLogicSourceConfig.CONSTRAINT_COLUMN_NAME, "uri");
+            put(MarkLogicSourceConfig.OUTPUT_FORMAT, MarkLogicSourceConfig.OUTPUT_TYPE.JSON.toString());
             put(MarkLogicSourceConfig.ROW_LIMIT, 1000);
         }};
-        DslQueryHandler dslQueryHandler = new DslQueryHandler(null, parsedConfig);
-        String expectedValue = "op.fromView(\"Medical\", \"Authors\").where(op.gt(op.col('" + constraintColumn + "'), '" + constraintValue + "')).orderBy(op.asc('" + constraintColumn + "')).limit(1000)";
-        String actualValue = dslQueryHandler.appendConstraintAndOrderByToQuery(constraintValue);
-        actualValue = dslQueryHandler.appendLimitToQuery(actualValue);
-        Assertions.assertEquals(expectedValue, actualValue);
+        assertEquals(expectedResult, appendConstraintOntoQuery(userDsl, localParsedConfig, "2"),
+            "The where clause should have been injected just after the closing paren of the fromDocUris function");
+    }
+
+    @Test
+    void wordQueryWithOrderByNoConstraintValue() {
+        String userDsl = "op.fromDocUris(cts.wordQuery('my phrase'))";
+        String expectedResult = userDsl + ".orderBy(op.asc('uri'))";
+        Map<String, Object> localParsedConfig = new HashMap<String, Object>() {{
+            put(MarkLogicSourceConfig.CONSTRAINT_COLUMN_NAME, "uri");
+            put(MarkLogicSourceConfig.OUTPUT_FORMAT, MarkLogicSourceConfig.OUTPUT_TYPE.JSON.toString());
+            put(MarkLogicSourceConfig.ROW_LIMIT, 1000);
+        }};
+        assertEquals(expectedResult, appendConstraintOntoQuery(userDsl, localParsedConfig, null),
+            "The where clause should have been injected just after the closing paren of the fromDocUris function");
+    }
+
+    @Test
+    void pullDataUsingFromLexicons() throws IOException {
+        loadThreeAuthorDocuments();
+
+        String userDsl = "op.fromLexicons({ID:cts.elementReference(xs.QName('ID')),LastName:cts.elementReference(xs.QName('LastName')),})";
+        String expectedResult = userDsl + ".where(op.gt(op.col('ID'), '2')).orderBy(op.asc('ID'))";
+
+        String result = appendConstraintOntoQuery(userDsl, parsedConfig, "2");
+        assertEquals(expectedResult, result, "The where clause should have been injected just after the closing paren of the fromLexicons function");
+
+        verifyQueryReturnsExpectedRows(null, 3, "First", parsedConfig);
+        verifyQueryReturnsExpectedRows(CONSTRAINT_VALUE, 1, "Third", parsedConfig);
+    }
+
+    @Test
+    void pullDataUsingFromLiterals() {
+        String userDsl = "op.fromLiterals([{LastName:'Second',ID:2},{LastName:'Third',ID:3},{LastName:'First',ID:1}])";
+        String expectedResult = userDsl + ".where(op.gt(op.col('ID'), '2')).orderBy(op.asc('ID'))";
+
+        String result = appendConstraintOntoQuery(userDsl, parsedConfig, "2");
+        assertEquals(expectedResult, result, "The where clause should have been injected just after the closing paren of the fromLiterals function");
+
+        verifyQueryReturnsExpectedRows(null, 3, "First", parsedConfig);
+        verifyQueryReturnsExpectedRows(CONSTRAINT_VALUE, 1, "Third", parsedConfig);
+    }
+
+    @Test
+    void pullDataUsingFromSQL() throws IOException {
+        loadThreeAuthorDocuments();
+
+        String userDsl = "op.fromSQL('SELECT Authors.ID, Authors.LastName FROM Authors')";
+        String expectedResult = userDsl + ".where(op.gt(op.col('ID'), '2')).orderBy(op.asc('ID'))";
+
+        String result = appendConstraintOntoQuery(userDsl, parsedConfig, "2");
+        assertEquals(expectedResult, result,
+            "The where clause should have been injected just after the closing paren of the fromSQL function");
+
+        verifyQueryReturnsExpectedRows(null, 3, "First", parsedConfig);
+        verifyQueryReturnsExpectedRows(CONSTRAINT_VALUE, 1, "Third", parsedConfig);
+    }
+
+    @Test
+    void pullDataUsingFromView() throws IOException {
+        loadThreeAuthorDocuments();
+
+        String userDsl = "op.fromView('Medical','Authors')";
+        String expectedResult = userDsl + ".where(op.gt(op.col('ID'), '2')).orderBy(op.asc('ID'))";
+
+        String result = appendConstraintOntoQuery(userDsl, parsedConfig, "2");
+        assertEquals(expectedResult, result,
+            "The where clause should have been injected just after the closing paren of the fromView function");
+
+        verifyQueryReturnsExpectedRows(null, 3, "First", parsedConfig);
+        verifyQueryReturnsExpectedRows(CONSTRAINT_VALUE, 1, "Third", parsedConfig);
     }
 }

--- a/src/test/java/com/marklogic/kafka/connect/source/SerializedConstraintInjectionPollTest.java
+++ b/src/test/java/com/marklogic/kafka/connect/source/SerializedConstraintInjectionPollTest.java
@@ -36,7 +36,8 @@ class SerializedConstraintInjectionPollTest extends AbstractIntegrationSourceTes
             try {
                 JsonNode authorJson = mapper.readTree((String) sourceRecord.value());
                 int recordId = authorJson.findPath("Medical.Authors.ID").findPath("value").intValue();
-                Assertions.assertTrue(recordId <= firstMaxConstraintColumnValueInteger);
+                Assertions.assertTrue(recordId <= firstMaxConstraintColumnValueInteger,
+                    recordId + " should be less than or equal to " + firstMaxConstraintColumnValueInteger);
             } catch (JsonProcessingException e) {
                 throw new RuntimeException(e);
             }
@@ -52,8 +53,10 @@ class SerializedConstraintInjectionPollTest extends AbstractIntegrationSourceTes
             try {
                 JsonNode authorJson = mapper.readTree((String) sourceRecord.value());
                 int recordId = authorJson.findPath("Medical.Authors.ID").findPath("value").intValue();
-                Assertions.assertTrue(recordId > firstMaxConstraintColumnValueInteger);
-                Assertions.assertTrue(recordId <= secondMaxConstraintColumnValueInteger);
+                Assertions.assertTrue(recordId > firstMaxConstraintColumnValueInteger,
+                    recordId + " should be less than or equal to " + firstMaxConstraintColumnValueInteger);
+                Assertions.assertTrue(recordId <= secondMaxConstraintColumnValueInteger,
+                    recordId + " should be less than or equal to " + secondMaxConstraintColumnValueInteger);
             } catch (JsonProcessingException e) {
                 throw new RuntimeException(e);
             }
@@ -132,7 +135,7 @@ class SerializedConstraintInjectionPollTest extends AbstractIntegrationSourceTes
             "The max value after polling once should be equal to the initial time");
         Assertions.assertEquals(1, newRecords.size());
         String initialRow = (String) newRecords.get(0).value();
-        Assertions.assertTrue(initialRow.contains("Initial"));
+        Assertions.assertTrue(initialRow.contains("Initial"), "Did not find 'Initial' in: " + initialRow);
 
         //    3) Insert a second document with a dateTime greater than that of the first row,
         String laterTime = "02:01:00";
@@ -152,6 +155,6 @@ class SerializedConstraintInjectionPollTest extends AbstractIntegrationSourceTes
             "The max value after polling once should be equal to the initial time");
         Assertions.assertEquals(1, newRecords.size());
         String laterRow = (String) newRecords.get(0).value();
-        Assertions.assertTrue(laterRow.contains("Later"));
+        Assertions.assertTrue(laterRow.contains("Later"), "Did not find 'Later' in: " + laterRow);
     }
 }

--- a/src/test/java/com/marklogic/kafka/connect/source/StoreConstraintValueInMarkLogicTest.java
+++ b/src/test/java/com/marklogic/kafka/connect/source/StoreConstraintValueInMarkLogicTest.java
@@ -119,8 +119,10 @@ class StoreConstraintValueInMarkLogicTest extends AbstractIntegrationSourceTest 
 
     private void assertOnlyRowsWithIdsAfterTheCurrentMaxValueGetDelivered(List<SourceRecord> newRecords) {
         assertEquals(2, newRecords.size(), "Only 2 of the 3 new records should be returned");
-        assertTrue(newRecords.toString().contains("\"Medical.Authors.ID\":{\"type\":\"xs:integer\",\"value\":6}"));
-        assertTrue(newRecords.toString().contains("\"Medical.Authors.ID\":{\"type\":\"xs:integer\",\"value\":7}"));
+        assertTrue(newRecords.toString().contains("\"Medical.Authors.ID\":{\"type\":\"xs:integer\",\"value\":6}"),
+            newRecords.toString() + " did not contain the expected value");
+        assertTrue(newRecords.toString().contains("\"Medical.Authors.ID\":{\"type\":\"xs:integer\",\"value\":7}"),
+            newRecords.toString() + " did not contain the expected value");
     }
 
     private void storeBadConstraintState() {

--- a/src/test/ml-config/databases/content-database.json
+++ b/src/test/ml-config/databases/content-database.json
@@ -33,6 +33,22 @@
       "namespace-uri": "",
       "range-value-positions": false,
       "scalar-type": "dateTime"
+    },
+    {
+      "collation": "",
+      "invalid-values": "reject",
+      "localname": "ID",
+      "namespace-uri": "",
+      "range-value-positions": false,
+      "scalar-type": "int"
+    },
+    {
+      "collation": "http://marklogic.com/collation/",
+      "invalid-values": "reject",
+      "localname": "LastName",
+      "namespace-uri": "",
+      "range-value-positions": false,
+      "scalar-type": "string"
     }
   ]
 }

--- a/src/test/ml-schemas/tde/authors-TDE.tdej
+++ b/src/test/ml-schemas/tde/authors-TDE.tdej
@@ -33,6 +33,23 @@
           }
         ]
       }
+    ],
+
+    "vars":[
+      {
+        "name":"prefix1",
+        "val":"\"http://marklogic.com/example/\""
+      }
+    ],
+    "triples":[{
+      "subject":{
+        "val":"sem:iri($prefix1||'person/'||AuthorList/Author[1]/ForeName||'_'||AuthorList/Author[1]/LastName)"},
+      "predicate":{
+        "val":"sem:iri(($prefix1||'authored'))"},
+      "object":{
+        "val":"xs:string(../../Journal/ISSN)"}
+      }
     ]
+
   }
 }


### PR DESCRIPTION
New tests to start covering all the Optic data access functions.

Take particular notice of "pullDataUsingFromLexicons". This one doesn't just verify the injection, but also uses the injection to retrieve limited data.

Also take notice of BALANCED_PARENS_REGEX_PATTERN and it's use in DslQueryHandler.injectConstraintIntoQuery. I believe it gives me the first op function (no matter what it contains).