### PR TITLE
Sanitizing the previous max value

### DIFF
--- a/src/main/java/com/marklogic/kafka/connect/source/QueryHandler.java
+++ b/src/main/java/com/marklogic/kafka/connect/source/QueryHandler.java
@@ -12,6 +12,9 @@ import static java.lang.String.format;
 /**
  * "Handles" a query in terms of modifying it to account for a constraint column and also retrieving the max value for
  * that constraint column based on the user's query.
+ *
+ * Note that implementations are expected to NOT be thread-safe; these are intended to be single-use objects that
+ * maintain state and should not be reused.
  */
 public interface QueryHandler {
 

--- a/src/main/java/com/marklogic/kafka/connect/source/SerializedQueryHandler.java
+++ b/src/main/java/com/marklogic/kafka/connect/source/SerializedQueryHandler.java
@@ -44,7 +44,9 @@ public class SerializedQueryHandler extends LoggingObject implements QueryHandle
         if (rowLimit > 0) {
             currentSerializedQuery = appendLimitToQuery(currentSerializedQuery);
         }
-        logger.info("Serialized query: " + currentSerializedQuery);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Serialized query: " + currentSerializedQuery);
+        }
         return databaseClient.newRowManager().newRawPlanDefinition(new StringHandle(currentSerializedQuery));
     }
 
@@ -88,7 +90,9 @@ public class SerializedQueryHandler extends LoggingObject implements QueryHandle
         String previousMaxConstraintColumnValue = null;
         try {
             String maxValueQuery = buildMaxValueSerializedQuery();
-            logger.info("Query for max constraint value: " + maxValueQuery);
+            if (logger.isDebugEnabled()) {
+                logger.debug("Query for max constraint value: " + maxValueQuery);
+            }
             RowManager rowMgr = databaseClient.newRowManager();
             RawPlanDefinition maxConstraintValueQuery = rowMgr.newRawPlanDefinition(new StringHandle(maxValueQuery));
             JacksonHandle handle = new JacksonHandle().withFormat(Format.JSON).withMimetype("application/json");

--- a/src/test/java/com/marklogic/kafka/connect/source/DslConstraintInjectionTest.java
+++ b/src/test/java/com/marklogic/kafka/connect/source/DslConstraintInjectionTest.java
@@ -1,39 +1,82 @@
 package com.marklogic.kafka.connect.source;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * This includes some tests that ensure that certain characters in the previous max value for a constraint column do
+ * not cause the modified user query to break. This also prevents possible "optic injection" attacks, though those
+ * seem extremely unusual given that the user already has control over the original query. In theory, a malicious user
+ * without access to the Kafka connector config but with the ability to insert data could insert a malicious value
+ * that allows for modifying the Optic query. This would require a string index on the constraint column, which itself
+ * seems highly unusual. And, in order to modify any data, the initial query would need to be an Optic Update query,
+ * and the MarkLogic user running the query would need to have the ability to modify data. So it's extremely remote
+ * that there's an attack vector here, but the previous max value is nonetheless sanitized.
+ */
 class DslConstraintInjectionTest extends AbstractIntegrationSourceTest {
-    private static final String constraintColumn = "lucky_number";
+    private static final String constraintColumn = "my_column";
     private static final String constraintValue = "52";
 
     @Test
     void testAccessorOnlyQuery() {
-        String originalDsl = "op.fromView(\"Medical\", \"Authors\")";
-        Map<String, Object> parsedConfig = new HashMap<String, Object>() {{
-            put(MarkLogicSourceConfig.DSL_QUERY, originalDsl);
-            put(MarkLogicSourceConfig.CONSTRAINT_COLUMN_NAME, constraintColumn);
-        }};
-        DslQueryHandler dslQueryHandler = new DslQueryHandler(null, parsedConfig);
-        String expectedValue = "op.fromView(\"Medical\", \"Authors\").where(op.gt(op.col('" + constraintColumn + "'), '" + constraintValue + "')).orderBy(op.asc('" + constraintColumn + "'))";
-        Assertions.assertEquals(expectedValue, dslQueryHandler.appendConstraintAndOrderByToQuery(constraintValue));
+        String expectedValue = "op.fromView('Medical', 'Authors')" +
+            ".where(op.gt(op.col('" + constraintColumn + "'), '" + constraintValue + "'))" +
+            ".orderBy(op.asc(op.col('" + constraintColumn + "')))";
+        assertEquals(expectedValue, injectValue(constraintValue));
     }
 
     @Test
     void testQueryWithLimit() {
-        String originalDsl = "op.fromView(\"Medical\", \"Authors\")";
+        String expectedValue = "op.fromView('Medical', 'Authors')" +
+            ".where(op.gt(op.col('" + constraintColumn + "'), '" + constraintValue + "'))" +
+            ".orderBy(op.asc(op.col('" + constraintColumn + "'))).limit(1000)";
+        assertEquals(expectedValue, injectValue(constraintValue, 1000));
+    }
+
+    @Test
+    void valueWithSingleQuotes() {
+        String expectedQuery = "op.fromView('Medical', 'Authors')" +
+            ".where(op.gt(op.col('my_column'), 'my odd value'))" +
+            ".orderBy(op.asc(op.col('my_column')))";
+        assertEquals(expectedQuery, injectValue("my 'odd' value"),
+            "To prevent the modified query from breaking, single quotes are removed from the previous max value");
+    }
+
+    @Test
+    void valueWithDoubleQuotes() {
+        String expectedQuery = "op.fromView('Medical', 'Authors')" +
+            ".where(op.gt(op.col('my_column'), 'my odd value'))" +
+            ".orderBy(op.asc(op.col('my_column')))";
+        assertEquals(expectedQuery, injectValue("my \"odd\" value"),
+            "To prevent the modified query from breaking, double quotes are removed from the previous max value");
+    }
+
+    @Test
+    void valueWithParens() {
+        String expectedQuery = "op.fromView('Medical', 'Authors')" +
+            ".where(op.gt(op.col('my_column'), 'my odd value'))" +
+            ".orderBy(op.asc(op.col('my_column')))";
+        assertEquals(expectedQuery, injectValue("my (odd) value"),
+            "To prevent the modified query from breaking, parentheses are removed from the previous max value");
+    }
+
+    private String injectValue(String value) {
+        return injectValue(value, null);
+    }
+
+    private String injectValue(String value, Integer rowLimit) {
+        String originalDsl = "op.fromView('Medical', 'Authors')";
         Map<String, Object> parsedConfig = new HashMap<String, Object>() {{
             put(MarkLogicSourceConfig.DSL_QUERY, originalDsl);
             put(MarkLogicSourceConfig.CONSTRAINT_COLUMN_NAME, constraintColumn);
-            put(MarkLogicSourceConfig.ROW_LIMIT, 1000);
         }};
-        DslQueryHandler dslQueryHandler = new DslQueryHandler(null, parsedConfig);
-        String expectedValue = "op.fromView(\"Medical\", \"Authors\").where(op.gt(op.col('" + constraintColumn + "'), '" + constraintValue + "')).orderBy(op.asc('" + constraintColumn + "')).limit(1000)";
-        String actualValue = dslQueryHandler.appendConstraintAndOrderByToQuery(constraintValue);
-        actualValue = dslQueryHandler.appendLimitToQuery(actualValue);
-        Assertions.assertEquals(expectedValue, actualValue);
+        if (rowLimit != null) {
+            parsedConfig.put(MarkLogicSourceConfig.ROW_LIMIT, rowLimit);
+        }
+        return new DslQueryHandler(null, parsedConfig).constrainUserQuery(value);
     }
 }


### PR DESCRIPTION
Couple other changes:

1. Combined the methods in DslQueryHandler for modifying the user query into `constrainUserQuery` so that the unit test only needs to invoke one method instead of two when rowLimit is specified
2. Changed info-level logging that I'd been using for debugging to debug-level logging, particularly since it involves user data that they may not want logged
3. For consistency in the DSL query, added op.col in a couple places so that we always use op.col to refer to a column (I'm a little paranoid about this from my time with Optic Update)