### PR TITLE
Added docs for rowLimit

### DIFF
--- a/src/main/java/com/marklogic/kafka/connect/source/DslQueryHandler.java
+++ b/src/main/java/com/marklogic/kafka/connect/source/DslQueryHandler.java
@@ -36,14 +36,10 @@ public class DslQueryHandler extends LoggingObject implements QueryHandler {
     public PlanBuilder.Plan newPlan(String previousMaxConstraintColumnValue) {
         currentDslQuery = appendConstraintAndOrderByToQuery(previousMaxConstraintColumnValue);
         if (rowLimit > 0) {
-            currentDslQuery = appendLimitToQuery(currentDslQuery);
+            currentDslQuery += ".limit(" + rowLimit + ")";
         }
         logger.info("DSL query: " + currentDslQuery);
         return databaseClient.newRowManager().newRawQueryDSLPlan(new StringHandle(currentDslQuery));
-    }
-
-    protected String appendLimitToQuery(String currentDslQuery) {
-        return currentDslQuery + ".limit(" + rowLimit + ")";
     }
 
     protected String appendConstraintAndOrderByToQuery(String previousMaxConstraintColumnValue) {

--- a/src/main/java/com/marklogic/kafka/connect/source/MarkLogicSourceConfig.java
+++ b/src/main/java/com/marklogic/kafka/connect/source/MarkLogicSourceConfig.java
@@ -21,7 +21,7 @@ public class MarkLogicSourceConfig extends MarkLogicConfig {
 
     public static final String DSL_QUERY = "ml.source.optic.dsl";
     public static final String SERIALIZED_QUERY = "ml.source.optic.serialized";
-    public static final String ROW_LIMIT = "ml.source.optic.row.limit";
+    public static final String ROW_LIMIT = "ml.source.optic.rowLimit";
     public static final String CONSTRAINT_COLUMN_NAME = "ml.source.optic.constraintColumn.name";
     public static final String CONSTRAINT_STORAGE_URI = "ml.source.optic.constraintColumn.uri";
     public static final String CONSTRAINT_STORAGE_PERMISSIONS = "ml.source.optic.constraintColumn.permissions";


### PR DESCRIPTION
I renamed "row.limit" to "rowLimit" as I think the latter is consistent with the existing "outputFormat" option. Also collapsed the `appendLimitToQuery` method as it was only used in one place (I think this was formerly used by a test, but no longer is). 