### PR TITLE
Adjusted most source logging to be at DEBUG level

### DIFF
--- a/src/main/java/com/marklogic/kafka/connect/sink/AbstractSinkTask.java
+++ b/src/main/java/com/marklogic/kafka/connect/sink/AbstractSinkTask.java
@@ -106,9 +106,7 @@ abstract class AbstractSinkTask extends SinkTask {
             record.headers().forEach(header -> headers.add(String.format("%s:%s", header.key(), header.value().toString())));
             logger.info("Record headers: {}", headers);
         }
-        if (logger.isDebugEnabled()) {
-            logger.debug("Processing record value {} in topic {}", record.value(), record.topic());
-        }
+        logger.debug("Processing record value {} in topic {}", record.value(), record.topic());
     }
 
     /**

--- a/src/main/java/com/marklogic/kafka/connect/sink/BulkDataServicesSinkTask.java
+++ b/src/main/java/com/marklogic/kafka/connect/sink/BulkDataServicesSinkTask.java
@@ -196,8 +196,8 @@ public class BulkDataServicesSinkTask extends AbstractSinkTask {
             // The stacktrace is not included here, as it will only contain references to Bulk Data Services code and
             // connector code, which won't help with debugging. The MarkLogic error log will be of much more value,
             // along with seeing the error message here.
-            logger.error("Skipping failed write; cause: " + throwable.getMessage() + "; check the MarkLogic error " +
-                "log file for additional information as to the cause of the failed write");
+            logger.error("Skipping failed write; cause: {}; check the MarkLogic error " +
+                "log file for additional information as to the cause of the failed write", throwable.getMessage());
             return IOEndpoint.BulkIOEndpointCaller.ErrorDisposition.SKIP_CALL;
         });
     }

--- a/src/main/java/com/marklogic/kafka/connect/sink/RunFlowWriteBatchListener.java
+++ b/src/main/java/com/marklogic/kafka/connect/sink/RunFlowWriteBatchListener.java
@@ -71,7 +71,7 @@ public class RunFlowWriteBatchListener extends LoggingObject implements WriteBat
         RunFlowResponse response = flowRunner.runFlow(inputs);
         flowRunner.awaitCompletion();
         if (logResponse) {
-            logger.info(format("Flow response for batch number %d:\n%s", batch.getJobBatchNumber(), response.toJson()));
+            logger.info("Flow response for batch number {}: {}", batch.getJobBatchNumber(), response.toJson());
         }
     }
 

--- a/src/main/java/com/marklogic/kafka/connect/sink/WriteBatcherSinkTask.java
+++ b/src/main/java/com/marklogic/kafka/connect/sink/WriteBatcherSinkTask.java
@@ -136,26 +136,26 @@ public class WriteBatcherSinkTask extends AbstractSinkTask {
     private void configureWriteBatcher(Map<String, Object> parsedConfig, WriteBatcher writeBatcher) {
         Integer batchSize = (Integer) parsedConfig.get(MarkLogicSinkConfig.DMSDK_BATCH_SIZE);
         if (batchSize != null) {
-            logger.info("DMSDK batch size: " + batchSize);
+            logger.info("DMSDK batch size: {}", batchSize);
             writeBatcher.withBatchSize(batchSize);
         }
 
         Integer threadCount = (Integer) parsedConfig.get(MarkLogicSinkConfig.DMSDK_THREAD_COUNT);
         if (threadCount != null) {
-            logger.info("DMSDK thread count: " + threadCount);
+            logger.info("DMSDK thread count: {}", threadCount);
             writeBatcher.withThreadCount(threadCount);
         }
 
         ServerTransform transform = buildServerTransform(parsedConfig);
         if (transform != null) {
             // Not logging transform parameters as they may contain sensitive values
-            logger.info("Will apply server transform: " + transform.getName());
+            logger.info("Will apply server transform: {}", transform.getName());
             writeBatcher.withTransform(transform);
         }
 
         String temporalCollection = (String) parsedConfig.get(MarkLogicSinkConfig.DOCUMENT_TEMPORAL_COLLECTION);
         if (StringUtils.hasText(temporalCollection)) {
-            logger.info("Will add documents to temporal collection: " + temporalCollection);
+            logger.info("Will add documents to temporal collection: {}", temporalCollection);
             writeBatcher.withTemporalCollection(temporalCollection);
         }
 
@@ -213,8 +213,8 @@ public class WriteBatcherSinkTask extends AbstractSinkTask {
                         t.addParameter(tokens[i], tokens[i + 1]);
                     }
                 } else {
-                    logger.warn(String.format("Unable to apply transform parameters to transform: %s; please set the " +
-                        "delimiter via the %s property", transform, MarkLogicSinkConfig.DMSDK_TRANSFORM_PARAMS_DELIMITER));
+                    logger.warn("Unable to apply transform parameters to transform: {}; please set the " +
+                        "delimiter via the {} property", transform, MarkLogicSinkConfig.DMSDK_TRANSFORM_PARAMS_DELIMITER);
                 }
             }
             return t;

--- a/src/main/java/com/marklogic/kafka/connect/source/DslQueryHandler.java
+++ b/src/main/java/com/marklogic/kafka/connect/source/DslQueryHandler.java
@@ -38,7 +38,7 @@ public class DslQueryHandler extends LoggingObject implements QueryHandler {
         if (rowLimit > 0) {
             currentDslQuery += ".limit(" + rowLimit + ")";
         }
-        logger.info("DSL query: " + currentDslQuery);
+        logger.debug("DSL query: {}", currentDslQuery);
         return databaseClient.newRowManager().newRawQueryDSLPlan(new StringHandle(currentDslQuery));
     }
 
@@ -59,7 +59,7 @@ public class DslQueryHandler extends LoggingObject implements QueryHandler {
     @Override
     public String getMaxConstraintColumnValue(long serverTimestamp) {
         String maxValueQuery = buildMaxValueDslQuery();
-        logger.info("Query for max constraint value: " + maxValueQuery);
+        logger.debug("Query for max constraint value: {}", maxValueQuery);
         RowManager rowMgr = databaseClient.newRowManager();
         RawQueryDSLPlan maxConstraintValueQuery = rowMgr.newRawQueryDSLPlan(new StringHandle(maxValueQuery));
         JacksonHandle handle = new JacksonHandle().withFormat(Format.JSON).withMimetype("application/json");

--- a/src/main/java/com/marklogic/kafka/connect/source/MarkLogicConstraintValueStore.java
+++ b/src/main/java/com/marklogic/kafka/connect/source/MarkLogicConstraintValueStore.java
@@ -76,7 +76,7 @@ public class MarkLogicConstraintValueStore extends ConstraintValueStore {
             databaseClient.newJSONDocumentManager().read(constraintStorageUri, resultHandle);
             return resultHandle.get().findPath("marklogicKafkaConstraintLastValue").textValue();
         } else {
-            logger.info("Did not find constraint value document at URI: " + constraintStorageUri);
+            logger.info("Did not find constraint value document at URI: {}", constraintStorageUri);
             return null;
         }
     }

--- a/src/main/java/com/marklogic/kafka/connect/source/SerializedQueryHandler.java
+++ b/src/main/java/com/marklogic/kafka/connect/source/SerializedQueryHandler.java
@@ -39,7 +39,7 @@ public class SerializedQueryHandler extends LoggingObject implements QueryHandle
         if (rowLimit > 0) {
             currentSerializedQuery = appendLimitToQuery(currentSerializedQuery);
         }
-        logger.info("Serialized query: " + currentSerializedQuery);
+        logger.debug("Serialized query: {}", currentSerializedQuery);
         return databaseClient.newRowManager().newRawPlanDefinition(new StringHandle(currentSerializedQuery));
     }
 
@@ -83,7 +83,7 @@ public class SerializedQueryHandler extends LoggingObject implements QueryHandle
         String previousMaxConstraintColumnValue = null;
         try {
             String maxValueQuery = buildMaxValueSerializedQuery();
-            logger.info("Query for max constraint value: " + maxValueQuery);
+            logger.debug("Query for max constraint value: {}", maxValueQuery);
             RowManager rowMgr = databaseClient.newRowManager();
             RawPlanDefinition maxConstraintValueQuery = rowMgr.newRawPlanDefinition(new StringHandle(maxValueQuery));
             JacksonHandle handle = new JacksonHandle().withFormat(Format.JSON).withMimetype("application/json");
@@ -91,7 +91,7 @@ public class SerializedQueryHandler extends LoggingObject implements QueryHandle
             JacksonHandle result = rowMgr.resultDoc(maxConstraintValueQuery, handle);
             previousMaxConstraintColumnValue = result.get().get("rows").get(0).get("constraint").get("value").asText();
         } catch (Exception ex) {
-            logger.warn("Failed to get a valid Maximum Constraint value: " + ex.getMessage());
+            logger.warn("Failed to get a valid Maximum Constraint value: {}", ex.getMessage());
         }
         return previousMaxConstraintColumnValue;
     }

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -16,6 +16,10 @@
     <appender-ref ref="STDOUT"/>
   </logger>
 
+  <logger name="com.marklogic.kafka" level="DEBUG" additivity="false">
+    <appender-ref ref="STDOUT"/>
+  </logger>
+
   <logger name="org.reflections" level="ERROR" additivity="false">
     <appender-ref ref="STDOUT"/>
   </logger>


### PR DESCRIPTION
Added README section on source connector logging.

Moved DLQ section in README to the bottom so that it's within the sink connector section and not in a section specific to DMSDK or Bulk Data Services. 