### PR TITLE
Throwing error when max value query fails

### DIFF
--- a/src/main/java/com/marklogic/kafka/connect/source/DslQueryHandler.java
+++ b/src/main/java/com/marklogic/kafka/connect/source/DslQueryHandler.java
@@ -61,16 +61,8 @@ public class DslQueryHandler extends LoggingObject implements QueryHandler {
         String maxValueQuery = buildMaxValueDslQuery();
         logger.debug("Query for max constraint value: {}", maxValueQuery);
         RowManager rowMgr = databaseClient.newRowManager();
-        RawQueryDSLPlan maxConstraintValueQuery = rowMgr.newRawQueryDSLPlan(new StringHandle(maxValueQuery));
-        JacksonHandle handle = new JacksonHandle().withFormat(Format.JSON).withMimetype("application/json");
-        handle.setPointInTimeQueryTimestamp(serverTimestamp);
-        JacksonHandle result = rowMgr.resultDoc(maxConstraintValueQuery, handle);
-        try {
-            return result.get().get("rows").get(0).get("constraint").get("value").asText();
-        } catch (Exception ex) {
-            throw new RuntimeException("Unable to get max constraint value; query: " + maxConstraintValueQuery +
-                "; response: " + result + "; cause: " + ex.getMessage());
-        }
+        return QueryHandlerUtil.executeMaxValuePlan(rowMgr, rowMgr.newRawQueryDSLPlan(new StringHandle(maxValueQuery)),
+            serverTimestamp, maxValueQuery);
     }
 
     private String buildMaxValueDslQuery() {

--- a/src/main/java/com/marklogic/kafka/connect/source/MarkLogicConstraintValueStore.java
+++ b/src/main/java/com/marklogic/kafka/connect/source/MarkLogicConstraintValueStore.java
@@ -46,13 +46,9 @@ public class MarkLogicConstraintValueStore extends ConstraintValueStore {
             insertCollections(metadataHandle.getCollections());
             JSONDocumentManager mgr = databaseClient.newJSONDocumentManager();
             mgr.write(constraintStorageUri, metadataHandle, handle);
-        } catch (JsonProcessingException e) {
-            String errorMessage = "Unable to store constraint value (" + constraintStateJson + ") at URI: "
-                + constraintStorageUri + "; cause: " + e.getMessage();
-            throw new RuntimeException(errorMessage, e);
-        } catch (FailedRequestException e) {
-            String errorMessage = "Unable to store constraint value (" + constraintStateJson + ") at URI: "
-                + constraintStorageUri + "; cause: " + e.getMessage();
+        } catch (Exception e) {
+            String errorMessage = String.format("Unable to store constraint document %s at URI: %s; cause: %s",
+                constraintStateJson, constraintStorageUri, e.getMessage());
             throw new RuntimeException(errorMessage, e);
         }
     }

--- a/src/main/java/com/marklogic/kafka/connect/source/QueryHandlerUtil.java
+++ b/src/main/java/com/marklogic/kafka/connect/source/QueryHandlerUtil.java
@@ -1,0 +1,34 @@
+package com.marklogic.kafka.connect.source;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.marklogic.client.expression.PlanBuilder;
+import com.marklogic.client.io.JacksonHandle;
+import com.marklogic.client.row.RowManager;
+
+abstract class QueryHandlerUtil {
+
+    /**
+     * Convenience method for executing a plan to get the maximum value for a particular constraint column; exists
+     * primarily to provide consistent error handling in case the query fails.
+     *
+     * @param rowManager
+     * @param maxValuePlan    the plan for getting a maximum value; the assumption is this will return a column named 'constraint'
+     *                        that contains the value
+     * @param serverTimestamp the MarkLogic server timestamp at which to run the plan's query
+     * @param maxValueQuery   a human-readable representation of the query; used solely for error handling
+     * @return
+     */
+    static String executeMaxValuePlan(RowManager rowManager, PlanBuilder.Plan maxValuePlan, long serverTimestamp, String maxValueQuery) {
+        JacksonHandle handle = new JacksonHandle();
+        handle.setPointInTimeQueryTimestamp(serverTimestamp);
+        JacksonHandle result = rowManager.resultDoc(maxValuePlan, handle);
+        JsonNode valueNode = result.get().at("/rows/0/constraint/value");
+        if (valueNode == null) {
+            String message = String.format(
+                "Unable to get max constraint value; query returned null; query: %s; server timestamp: %d; response: %s",
+                maxValueQuery, serverTimestamp, result.get());
+            throw new RuntimeException(message);
+        }
+        return valueNode.asText();
+    }
+}


### PR DESCRIPTION
Both the DSL and serialized handlers do the same thing now. Tried a base class for providing the common behavior, but that felt a little over-engineered, so resurrected QueryHandlerUtil and added a static convenience method there instead. 

Also modified the catch block in MarkLogicConstraintValueStore to catch any exception and throw the same error. 

For testing, I had to manually force an error in order to get executeMaxValuePlan to fail - verified that the error message is correctly constructed. 
