### PR TITLE
Using op.col consistently

### DIFF
--- a/src/main/java/com/marklogic/kafka/connect/source/DslQueryHandler.java
+++ b/src/main/java/com/marklogic/kafka/connect/source/DslQueryHandler.java
@@ -50,7 +50,7 @@ public class DslQueryHandler extends LoggingObject implements QueryHandler {
                 String sanitizedValue = previousMaxConstraintColumnValue.replaceAll(VALUE_SANITIZATION_PATTERN, "");
                 constraintPhrase = String.format(".where(op.gt(op.col('%s'), '%s'))", constraintColumnName, sanitizedValue);
             }
-            constraintPhrase += ".orderBy(op.asc('" + constraintColumnName + "'))";
+            constraintPhrase += ".orderBy(op.asc(op.col('" + constraintColumnName + "')))";
             constrainedDsl = userDslQuery + constraintPhrase;
         }
         return constrainedDsl;
@@ -66,7 +66,11 @@ public class DslQueryHandler extends LoggingObject implements QueryHandler {
     }
 
     private String buildMaxValueDslQuery() {
-        return String.format("%s.orderBy(op.desc(\"%s\")).limit(1).select([op.as(\"constraint\", op.col(\"%s\"))])", currentDslQuery, constraintColumnName, constraintColumnName);
+        return String.format("%s" +
+            ".orderBy(op.desc(op.col('%s')))" +
+            ".limit(1)" +
+            ".select([op.as('constraint', op.col('%s'))])",
+            currentDslQuery, constraintColumnName, constraintColumnName);
     }
 
     public String getCurrentQuery() {

--- a/src/test/java/com/marklogic/kafka/connect/source/DslConstraintInjectionPollTest.java
+++ b/src/test/java/com/marklogic/kafka/connect/source/DslConstraintInjectionPollTest.java
@@ -13,7 +13,7 @@ class DslConstraintInjectionPollTest extends AbstractIntegrationSourceTest {
     void orderAuthorsByIDNumberAndLimit3() throws InterruptedException {
         loadFifteenAuthorsIntoMarkLogic();
         String constraintColumnName = "ID";
-        String limitedAuthorsDsl = AUTHORS_OPTIC_DSL + ".orderBy(op.asc(\"" + constraintColumnName + "\"))";
+        String limitedAuthorsDsl = AUTHORS_OPTIC_DSL + ".orderBy(op.asc(op.col('" + constraintColumnName + "')))";
 
         RowManagerSourceTask task = startSourceTask(
             MarkLogicSourceConfig.DSL_QUERY, limitedAuthorsDsl,
@@ -46,7 +46,7 @@ class DslConstraintInjectionPollTest extends AbstractIntegrationSourceTest {
     void orderAuthorsByDateAndLimit3() throws InterruptedException {
         loadFifteenAuthorsIntoMarkLogic();
         String constraintColumnName = "Date";
-        String limitedAuthorsDsl = AUTHORS_OPTIC_DSL + ".orderBy(op.asc(\"" + constraintColumnName + "\"))";
+        String limitedAuthorsDsl = AUTHORS_OPTIC_DSL + ".orderBy(op.asc(op.col('" + constraintColumnName + "')))";
 
         RowManagerSourceTask task = startSourceTask(
             MarkLogicSourceConfig.DSL_QUERY, limitedAuthorsDsl,
@@ -68,7 +68,7 @@ class DslConstraintInjectionPollTest extends AbstractIntegrationSourceTest {
     void orderAuthorsByDateTimeAndLimit3() throws InterruptedException {
         loadFifteenAuthorsIntoMarkLogic();
         String constraintColumnName = "DateTime";
-        String limitedAuthorsDsl = AUTHORS_OPTIC_DSL + ".orderBy(op.asc(\"" + constraintColumnName + "\"))";
+        String limitedAuthorsDsl = AUTHORS_OPTIC_DSL + ".orderBy(op.asc(op.col('" + constraintColumnName + "')))";
 
         RowManagerSourceTask task = startSourceTask(
             MarkLogicSourceConfig.DSL_QUERY, limitedAuthorsDsl,
@@ -93,7 +93,7 @@ class DslConstraintInjectionPollTest extends AbstractIntegrationSourceTest {
     @Test
     void insertNewDataBeforeSecondPoll() throws Exception {
         String constraintColumnName = "DateTime";
-        String authorsDsl = AUTHORS_OPTIC_DSL + ".orderBy(op.asc(\"" + constraintColumnName + "\"))";
+        String authorsDsl = AUTHORS_OPTIC_DSL + ".orderBy(op.asc(op.col('" + constraintColumnName + "')))";
 
         RowManagerSourceTask task = startSourceTask(
             MarkLogicSourceConfig.DSL_QUERY, authorsDsl,

--- a/src/test/java/com/marklogic/kafka/connect/source/DslConstraintInjectionTest.java
+++ b/src/test/java/com/marklogic/kafka/connect/source/DslConstraintInjectionTest.java
@@ -20,14 +20,14 @@ class DslConstraintInjectionTest extends AbstractIntegrationSourceTest {
     @Test
     void testAccessorOnlyQuery() {
         String userDsl = "op.fromView('Medical','Authors')";
-        String expectedValue = userDsl + ".where(op.gt(op.col('ID'), '2')).orderBy(op.asc('ID'))";
+        String expectedValue = userDsl + ".where(op.gt(op.col('ID'), '2')).orderBy(op.asc(op.col('ID')))";
         assertEquals(expectedValue, appendConstraintOntoQuery(userDsl, parsedConfig, "2"));
     }
 
     @Test
     void wordQueryWithPhraseAndFollowOnFunction() {
         String userDsl = "op.fromDocUris(cts.wordQuery('my phrase').joinDoc('abc'))";
-        String expectedResult = userDsl + ".where(op.gt(op.col('ID'), '2')).orderBy(op.asc('ID'))";
+        String expectedResult = userDsl + ".where(op.gt(op.col('ID'), '2')).orderBy(op.asc(op.col('ID')))";
         assertEquals(expectedResult, appendConstraintOntoQuery(userDsl, parsedConfig, "2"),
             "The where clause should have been injected just after the closing paren of the fromDocUris function");
     }
@@ -35,7 +35,7 @@ class DslConstraintInjectionTest extends AbstractIntegrationSourceTest {
     @Test
     void wordQueryWithOrderBy() {
         String userDsl = "op.fromDocUris(cts.wordQuery('my phrase'))";
-        String expectedResult = userDsl + ".where(op.gt(op.col('uri'), '2')).orderBy(op.asc('uri'))";
+        String expectedResult = userDsl + ".where(op.gt(op.col('uri'), '2')).orderBy(op.asc(op.col('uri')))";
         Map<String, Object> localParsedConfig = new HashMap<String, Object>() {{
             put(MarkLogicSourceConfig.CONSTRAINT_COLUMN_NAME, "uri");
             put(MarkLogicSourceConfig.OUTPUT_FORMAT, MarkLogicSourceConfig.OUTPUT_TYPE.JSON.toString());
@@ -48,7 +48,7 @@ class DslConstraintInjectionTest extends AbstractIntegrationSourceTest {
     @Test
     void wordQueryWithOrderByNoConstraintValue() {
         String userDsl = "op.fromDocUris(cts.wordQuery('my phrase'))";
-        String expectedResult = userDsl + ".orderBy(op.asc('uri'))";
+        String expectedResult = userDsl + ".orderBy(op.asc(op.col('uri')))";
         Map<String, Object> localParsedConfig = new HashMap<String, Object>() {{
             put(MarkLogicSourceConfig.CONSTRAINT_COLUMN_NAME, "uri");
             put(MarkLogicSourceConfig.OUTPUT_FORMAT, MarkLogicSourceConfig.OUTPUT_TYPE.JSON.toString());
@@ -63,7 +63,7 @@ class DslConstraintInjectionTest extends AbstractIntegrationSourceTest {
         loadThreeAuthorDocuments();
 
         String userDsl = "op.fromLexicons({ID:cts.elementReference(xs.QName('ID')),LastName:cts.elementReference(xs.QName('LastName')),})";
-        String expectedResult = userDsl + ".where(op.gt(op.col('ID'), '2')).orderBy(op.asc('ID'))";
+        String expectedResult = userDsl + ".where(op.gt(op.col('ID'), '2')).orderBy(op.asc(op.col('ID')))";
 
         String result = appendConstraintOntoQuery(userDsl, parsedConfig, "2");
         assertEquals(expectedResult, result, "The where clause should have been injected just after the closing paren of the fromLexicons function");
@@ -75,7 +75,7 @@ class DslConstraintInjectionTest extends AbstractIntegrationSourceTest {
     @Test
     void pullDataUsingFromLiterals() {
         String userDsl = "op.fromLiterals([{LastName:'Second',ID:2},{LastName:'Third',ID:3},{LastName:'First',ID:1}])";
-        String expectedResult = userDsl + ".where(op.gt(op.col('ID'), '2')).orderBy(op.asc('ID'))";
+        String expectedResult = userDsl + ".where(op.gt(op.col('ID'), '2')).orderBy(op.asc(op.col('ID')))";
 
         String result = appendConstraintOntoQuery(userDsl, parsedConfig, "2");
         assertEquals(expectedResult, result, "The where clause should have been injected just after the closing paren of the fromLiterals function");
@@ -89,7 +89,7 @@ class DslConstraintInjectionTest extends AbstractIntegrationSourceTest {
         loadThreeAuthorDocuments();
 
         String userDsl = "op.fromSQL('SELECT Authors.ID, Authors.LastName FROM Authors')";
-        String expectedResult = userDsl + ".where(op.gt(op.col('ID'), '2')).orderBy(op.asc('ID'))";
+        String expectedResult = userDsl + ".where(op.gt(op.col('ID'), '2')).orderBy(op.asc(op.col('ID')))";
 
         String result = appendConstraintOntoQuery(userDsl, parsedConfig, "2");
         assertEquals(expectedResult, result,
@@ -104,7 +104,7 @@ class DslConstraintInjectionTest extends AbstractIntegrationSourceTest {
         loadThreeAuthorDocuments();
 
         String userDsl = "op.fromView('Medical','Authors')";
-        String expectedResult = userDsl + ".where(op.gt(op.col('ID'), '2')).orderBy(op.asc('ID'))";
+        String expectedResult = userDsl + ".where(op.gt(op.col('ID'), '2')).orderBy(op.asc(op.col('ID')))";
 
         String result = appendConstraintOntoQuery(userDsl, parsedConfig, "2");
         assertEquals(expectedResult, result,
@@ -118,7 +118,7 @@ class DslConstraintInjectionTest extends AbstractIntegrationSourceTest {
     void valueWithSingleQuotes() {
         String expectedQuery = "op.fromView('Medical', 'Authors')" +
             ".where(op.gt(op.col('ID'), 'my odd value'))" +
-            ".orderBy(op.asc('ID'))";
+            ".orderBy(op.asc(op.col('ID')))";
         assertEquals(expectedQuery, injectValue("my 'odd' value"),
             "To prevent the modified query from breaking, single quotes are removed from the previous max value");
     }
@@ -127,7 +127,7 @@ class DslConstraintInjectionTest extends AbstractIntegrationSourceTest {
     void valueWithDoubleQuotes() {
         String expectedQuery = "op.fromView('Medical', 'Authors')" +
             ".where(op.gt(op.col('ID'), 'my odd value'))" +
-            ".orderBy(op.asc('ID'))";
+            ".orderBy(op.asc(op.col('ID')))";
         assertEquals(expectedQuery, injectValue("my \"odd\" value"),
             "To prevent the modified query from breaking, double quotes are removed from the previous max value");
     }
@@ -136,7 +136,7 @@ class DslConstraintInjectionTest extends AbstractIntegrationSourceTest {
     void valueWithParens() {
         String expectedQuery = "op.fromView('Medical', 'Authors')" +
             ".where(op.gt(op.col('ID'), 'my odd value'))" +
-            ".orderBy(op.asc('ID'))";
+            ".orderBy(op.asc(op.col('ID')))";
         assertEquals(expectedQuery, injectValue("my (odd) value"),
             "To prevent the modified query from breaking, parentheses are removed from the previous max value");
     }

--- a/src/test/java/com/marklogic/kafka/connect/source/StoreConstraintValueInMarkLogicTest.java
+++ b/src/test/java/com/marklogic/kafka/connect/source/StoreConstraintValueInMarkLogicTest.java
@@ -22,7 +22,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class StoreConstraintValueInMarkLogicTest extends AbstractIntegrationSourceTest {
 
     private final String constraintColumnName = "ID";
-    private final String limitedAuthorsDsl = AUTHORS_OPTIC_DSL + ".orderBy(op.asc(\"" + constraintColumnName + "\"))";
+    private final String limitedAuthorsDsl = AUTHORS_OPTIC_DSL + ".orderBy(op.asc(op.col('" + constraintColumnName + "')))";
     private final String constraintStorageUri = "/kafka/currentConstrainInfo";
     private final String roleName = "kafka-test-minimal-user";
     private final String constraintStoragePermissions = roleName + ",read," + roleName + ",update";

--- a/src/test/resources/confluent/marklogic-employees-source.json
+++ b/src/test/resources/confluent/marklogic-employees-source.json
@@ -10,7 +10,7 @@
     "ml.connection.username": "admin",
     "ml.connection.password": "admin",
     "ml.connection.securityContextType": "DIGEST",
-    "ml.source.optic.dsl": "op.fromView('demo', 'employee').orderBy(op.asc('incrementing_id'))",
+    "ml.source.optic.dsl": "op.fromView('demo', 'employee').orderBy(op.asc(op.col('incrementing_id')))",
     "ml.source.optic.constraintColumn.name": "incrementing_id",
     "ml.source.optic.constraintColumn.uri": "/employee-kafka-data.json",
     "ml.source.optic.constraintColumn.collections": "kafka-config",


### PR DESCRIPTION
This is primarily paranoia based on a fear of something not working if a query uses op.col in some cases but not in all cases. 