### PR TITLE
DEVEXP-127: Using ML server timestamp for key strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ this, the following properties must be configured:
 The following optional properties can also be configured:
 
 - `ml.source.waitTime` = amount of time, in milliseconds, that the connector will wait on each poll before running the Optic query; defaults to 5000
+- `ml.source.key.strategy` = strategy for generating keys for each source records; defaults to "NONE", and can also be "UUID" or "TIMESTAMP"
 - `ml.source.optic.outputFormat` = the format of rows returned by the Optic query; defaults to "JSON", and can instead be "XML" or "CSV"
 - `ml.source.optic.rowLimit` = the maximum number of rows to retrieve per poll
 - `ml.source.optic.constraintColumn.name` = name of a column returned by the Optic query to use for constraining results on subsequent runs
@@ -239,6 +240,16 @@ containing the values for the row; example:
 Medical.Authors.ID,Medical.Authors.LastName,Medical.Authors.ForeName,Medical.Authors.Date,Medical.Authors.DateTime
 2,Smith,Jane,2022-05-11,2022-05-11T10:00:00
 ```
+
+### Generating a key for each source record
+
+Each source record returned by a Kafka source connector can have a key defined. A key is optional, and thus by default, 
+the MarkLogic Kafka connector will set the key to `null` on each record it returns. Depending on your requirements, 
+you can configure one of the following strategies via the `ml.source.key.strategy` option:
+
+- UUID = generate a UUID for each source record
+- TIMESTAMP = generate a key consisting of the [MarkLogic server timestamp](https://docs.marklogic.com/guide/app-dev/point_in_time), 
+  a hyphen, and then the row number of the row represented by the source record
 
 ### Limiting how many rows are returned
 

--- a/src/main/java/com/marklogic/kafka/connect/source/JsonPlanInvoker.java
+++ b/src/main/java/com/marklogic/kafka/connect/source/JsonPlanInvoker.java
@@ -13,11 +13,11 @@ import java.util.Map;
 class JsonPlanInvoker implements PlanInvoker {
 
     private DatabaseClient client;
-    private KeyGenerator keyGenerator;
+    private Map<String, Object> parsedConfig;
 
     public JsonPlanInvoker(DatabaseClient client, Map<String, Object> parsedConfig) {
         this.client = client;
-        this.keyGenerator = KeyGenerator.newKeyGenerator(parsedConfig);
+        this.parsedConfig = parsedConfig;
     }
 
     @Override
@@ -33,11 +33,9 @@ class JsonPlanInvoker implements PlanInvoker {
          */
         JsonNode doc = result.get();
         if (doc != null && doc.has("rows")) {
-            long rowNumber = 1;
+            KeyGenerator keyGenerator = KeyGenerator.newKeyGenerator(this.parsedConfig, baseHandle.getServerTimestamp());
             for (JsonNode row : doc.get("rows")) {
-                String key = keyGenerator.generateKey(rowNumber);
-                rowNumber++;
-                records.add(new SourceRecord(null, null, topic, null, key,null, row.toString()));
+                records.add(new SourceRecord(null, null, topic, null, keyGenerator.generateKey(), null, row.toString()));
             }
         }
         return new Results(records, baseHandle.getServerTimestamp());

--- a/src/main/java/com/marklogic/kafka/connect/source/KeyGenerator.java
+++ b/src/main/java/com/marklogic/kafka/connect/source/KeyGenerator.java
@@ -2,18 +2,40 @@ package com.marklogic.kafka.connect.source;
 
 import java.util.Map;
 
+/**
+ * Defines a strategy for generating a key for each source record. Implementations are NOT expected to be thread-safe
+ * nor reusable - the intent is that for each poll call in the source connector that returns one or more source
+ * records, a new key generator will be constructed.
+ */
 public interface KeyGenerator {
-    String generateKey(long rowNumber);
 
-    static KeyGenerator newKeyGenerator(Map<String, Object> parsedConfig) {
-        String keyStrategy = parsedConfig.get(MarkLogicSourceConfig.KEY_STRATEGY).toString().toUpperCase();
+    /**
+     * Generate a new key, which currently is not based on a particular source record. As the need arises - for example,
+     * if we choose to support a strategy for generating a key on a particular column value - arguments can be added
+     * to this method.
+     *
+     * @return
+     */
+    String generateKey();
+
+    /**
+     * Factory method, with an unfortunate small leaky abstraction - one implementation requires the MarkLogic
+     * server timestamp.
+     *
+     * @param parsedConfig    the connector configuration
+     * @param serverTimestamp the MarkLogic server timestamp associated with the set of rows returned by the call to MarkLogic
+     * @return
+     */
+    static KeyGenerator newKeyGenerator(Map<String, Object> parsedConfig, long serverTimestamp) {
+        Object value = parsedConfig.get(MarkLogicSourceConfig.KEY_STRATEGY);
+        final String keyStrategy = value != null ? value.toString().toUpperCase() : null;
         switch (keyStrategy) {
             case "UUID":
                 return new UuidKeyGenerator();
             case "TIMESTAMP":
-                return new TimestampKeyGenerator();
+                return new TimestampKeyGenerator(serverTimestamp);
             default:
-                 return new NullKeyGenerator();
+                return new NullKeyGenerator();
         }
     }
 }

--- a/src/main/java/com/marklogic/kafka/connect/source/NullKeyGenerator.java
+++ b/src/main/java/com/marklogic/kafka/connect/source/NullKeyGenerator.java
@@ -3,7 +3,7 @@ package com.marklogic.kafka.connect.source;
 public class NullKeyGenerator implements KeyGenerator {
 
     @Override
-    public String generateKey(long rowNumber) {
+    public String generateKey() {
         return null;
     }
 }

--- a/src/main/java/com/marklogic/kafka/connect/source/TimestampKeyGenerator.java
+++ b/src/main/java/com/marklogic/kafka/connect/source/TimestampKeyGenerator.java
@@ -1,11 +1,21 @@
 package com.marklogic.kafka.connect.source;
 
-import java.time.Instant;
-
+/**
+ * Generates keys based on a MarkLogic server timestamp. The expectation is that there's value in knowing that a set
+ * of records were all retrieved at a particular timestamp, which would allow a user to run a query at that exact
+ * timestamp to confirm they get the same results that were sent to Kafka.
+ */
 public class TimestampKeyGenerator implements KeyGenerator {
 
+    private final long serverTimestamp;
+    private int rowNumber;
+
+    public TimestampKeyGenerator(long serverTimestamp) {
+        this.serverTimestamp = serverTimestamp;
+    }
+
     @Override
-    public String generateKey(long rowNumber) {
-        return Long.toString(Instant.now().toEpochMilli()).concat("-").concat(Long.toString(rowNumber));
+    public String generateKey() {
+        return serverTimestamp + "-" + ++rowNumber;
     }
 }

--- a/src/main/java/com/marklogic/kafka/connect/source/UuidKeyGenerator.java
+++ b/src/main/java/com/marklogic/kafka/connect/source/UuidKeyGenerator.java
@@ -5,7 +5,7 @@ import java.util.UUID;
 public class UuidKeyGenerator implements KeyGenerator {
 
     @Override
-    public String generateKey(long rowNumber) {
+    public String generateKey() {
         return UUID.randomUUID().toString();
     }
 }


### PR DESCRIPTION
Also adjusted the `KeyGenerator` interface to not require a row number so that the plan invokers don't have to manage that; the timestamp generator can easily manage that itself. In addition, a new generator is constructed each time one or more rows are returned. 

Added a README section for key strategy as well. 