### PR TITLE
Moved Kafka-specific classes out of client.ext package

### DIFF
--- a/src/main/java/com/marklogic/kafka/connect/sink/DefaultSinkRecordConverter.java
+++ b/src/main/java/com/marklogic/kafka/connect/sink/DefaultSinkRecordConverter.java
@@ -1,10 +1,10 @@
 package com.marklogic.kafka.connect.sink;
 
 import com.marklogic.client.document.DocumentWriteOperation;
-import com.marklogic.client.ext.document.DocumentWriteOperationBuilder;
-import com.marklogic.client.ext.document.RecordContent;
-import com.marklogic.client.id.strategy.IdStrategy;
-import com.marklogic.client.id.strategy.IdStrategyFactory;
+import com.marklogic.kafka.connect.source.DocumentWriteOperationBuilder;
+import com.marklogic.kafka.connect.source.RecordContent;
+import com.marklogic.kafka.connect.sink.idstrategy.IdStrategy;
+import com.marklogic.kafka.connect.sink.idstrategy.IdStrategyFactory;
 import com.marklogic.client.io.BytesHandle;
 import com.marklogic.client.io.DocumentMetadataHandle;
 import com.marklogic.client.io.Format;

--- a/src/main/java/com/marklogic/kafka/connect/sink/idstrategy/DefaultStrategy.java
+++ b/src/main/java/com/marklogic/kafka/connect/sink/idstrategy/DefaultStrategy.java
@@ -1,12 +1,15 @@
-package com.marklogic.client.id.strategy;
+package com.marklogic.kafka.connect.sink.idstrategy;
 
 import com.marklogic.client.io.marker.AbstractWriteHandle;
 
-public class KafkaMetaStrategy implements IdStrategy {
+import java.util.UUID;
+
+
+public class DefaultStrategy implements IdStrategy {
 
     @Override
     public String generateId(AbstractWriteHandle content, String topic, Integer partition, long offset) {
-        return topic + "/" + partition.toString() + "/" + offset;
+        return UUID.randomUUID().toString();
     }
 
 }

--- a/src/main/java/com/marklogic/kafka/connect/sink/idstrategy/HashedJSONPathsStrategy.java
+++ b/src/main/java/com/marklogic/kafka/connect/sink/idstrategy/HashedJSONPathsStrategy.java
@@ -1,4 +1,4 @@
-package com.marklogic.client.id.strategy;
+package com.marklogic.kafka.connect.sink.idstrategy;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/src/main/java/com/marklogic/kafka/connect/sink/idstrategy/HashedKafkaMetaStrategy.java
+++ b/src/main/java/com/marklogic/kafka/connect/sink/idstrategy/HashedKafkaMetaStrategy.java
@@ -1,4 +1,4 @@
-package com.marklogic.client.id.strategy;
+package com.marklogic.kafka.connect.sink.idstrategy;
 
 import com.marklogic.client.io.marker.AbstractWriteHandle;
 import org.slf4j.Logger;

--- a/src/main/java/com/marklogic/kafka/connect/sink/idstrategy/IdStrategy.java
+++ b/src/main/java/com/marklogic/kafka/connect/sink/idstrategy/IdStrategy.java
@@ -1,4 +1,4 @@
-package com.marklogic.client.id.strategy;
+package com.marklogic.kafka.connect.sink.idstrategy;
 
 import com.marklogic.client.io.marker.AbstractWriteHandle;
 

--- a/src/main/java/com/marklogic/kafka/connect/sink/idstrategy/IdStrategyFactory.java
+++ b/src/main/java/com/marklogic/kafka/connect/sink/idstrategy/IdStrategyFactory.java
@@ -1,4 +1,4 @@
-package com.marklogic.client.id.strategy;
+package com.marklogic.kafka.connect.sink.idstrategy;
 
 import com.marklogic.kafka.connect.sink.MarkLogicSinkConfig;
 

--- a/src/main/java/com/marklogic/kafka/connect/sink/idstrategy/JSONPathStrategy.java
+++ b/src/main/java/com/marklogic/kafka/connect/sink/idstrategy/JSONPathStrategy.java
@@ -1,4 +1,4 @@
-package com.marklogic.client.id.strategy;
+package com.marklogic.kafka.connect.sink.idstrategy;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marklogic.client.io.marker.AbstractWriteHandle;

--- a/src/main/java/com/marklogic/kafka/connect/sink/idstrategy/KafkaMetaStrategy.java
+++ b/src/main/java/com/marklogic/kafka/connect/sink/idstrategy/KafkaMetaStrategy.java
@@ -1,15 +1,12 @@
-package com.marklogic.client.id.strategy;
+package com.marklogic.kafka.connect.sink.idstrategy;
 
 import com.marklogic.client.io.marker.AbstractWriteHandle;
 
-import java.util.UUID;
-
-
-public class DefaultStrategy implements IdStrategy {
+public class KafkaMetaStrategy implements IdStrategy {
 
     @Override
     public String generateId(AbstractWriteHandle content, String topic, Integer partition, long offset) {
-        return UUID.randomUUID().toString();
+        return topic + "/" + partition.toString() + "/" + offset;
     }
 
 }

--- a/src/main/java/com/marklogic/kafka/connect/source/DocumentWriteOperationBuilder.java
+++ b/src/main/java/com/marklogic/kafka/connect/source/DocumentWriteOperationBuilder.java
@@ -1,4 +1,4 @@
-package com.marklogic.client.ext.document;
+package com.marklogic.kafka.connect.source;
 
 import com.marklogic.client.document.DocumentWriteOperation;
 import com.marklogic.client.ext.util.DefaultDocumentPermissionsParser;

--- a/src/main/java/com/marklogic/kafka/connect/source/RecordContent.java
+++ b/src/main/java/com/marklogic/kafka/connect/source/RecordContent.java
@@ -1,4 +1,4 @@
-package com.marklogic.client.ext.document;
+package com.marklogic.kafka.connect.source;
 
 import com.marklogic.client.io.DocumentMetadataHandle;
 import com.marklogic.client.io.marker.AbstractWriteHandle;


### PR DESCRIPTION
The IdStrategy is Kakfa-specific, and DocumentWriteOperationBuilder can be used for inspiration for something reusable in the Java Client. 